### PR TITLE
ZERO-29 [Feat] : 공통 컴포넌트 sidebar 제작

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   webpack: (config) => {
-    config.module.rules.push({
+    config.module.rules.unshift({
       test: /\.svg$/,
       use: ['@svgr/webpack'],
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "react": "^18",
         "react-dom": "^18",
         "zustand": "^5.0.0-rc.2"
-
       },
       "devDependencies": {
         "@svgr/webpack": "^8.1.0",
@@ -3533,7 +3532,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-
       "license": "MIT",
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
@@ -3696,7 +3694,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -6418,7 +6415,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -6429,31 +6425,18 @@
         "tslib": "^2.0.3"
       }
     },
-
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "dev": true,
       "license": "MIT"
-
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "dev": true,
-
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7972,7 +7955,6 @@
       "integrity": "sha512-KqjHOJKogOUt5Bs752ykCeiwvi0fKVkr5oqsFNt/8px/tA8scFPIlkygsf6jXrfCqGHz7VflA6+yytWuM+XhFw==",
       "dev": true,
       "license": "MIT",
-
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8286,7 +8268,6 @@
         "node": ">=4"
       }
     },
-
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "react": "^18",
     "react-dom": "^18",
     "zustand": "^5.0.0-rc.2"
-
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",

--- a/src/components/@shared/NavBar.tsx
+++ b/src/components/@shared/NavBar.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Menu from 'public/icons/menu.svg';
 
-const NavBar = () => {
+export default function NavBar() {
   const router = useRouter();
   const [isLogoOnlyPage, setIsLogoOnlyPage] = useState(false);
 
@@ -16,7 +16,7 @@ const NavBar = () => {
     setIsLogoOnlyPage(logoOnlyPages.includes(router.pathname));
   }, [router.pathname]);
   return (
-    <header className=" flex h-16 items-center justify-center bg-background-secondary px-6">
+    <header className=" flex h-16 items-center justify-center border-b border-border-primary border-opacity-50 bg-background-secondary px-6">
       <nav className="flex h-8 w-[1200px]  items-center justify-between text-text-primary max-xl:w-[696px] max-md:w-[343px] ">
         <div className="flex items-center gap-10 max-md:gap-5">
           <button className="md:hidden">
@@ -50,6 +50,4 @@ const NavBar = () => {
       </nav>
     </header>
   );
-};
-
-export default NavBar;
+}

--- a/src/components/@shared/SideBar.tsx
+++ b/src/components/@shared/SideBar.tsx
@@ -1,0 +1,106 @@
+import { ReactNode, useEffect, useRef, useState } from 'react';
+import XIcon from 'public/icons/x.svg';
+import clsx from 'clsx';
+import Button from '@pages/components/@shared/Button';
+import CheckWhiteIcon from 'public/icons/check_white.svg';
+
+interface SideBarProps {
+  children: ReactNode;
+  trigger: (toggle: () => void) => ReactNode;
+  position: 'left' | 'right';
+  clickEvent?: () => void;
+}
+
+/**
+ * SideBar 공통 컴포넌트
+ * @param children 사이드바 안의 컨텐츠 넣어주시면 됩니다
+ * @param trigger 사이드바를 여는 트리거로 사이드 바를 여는 버튼 혹은 글을 적용하면 됩니다.
+ * @param position 왼쪽에서 열리는 사이드바인지 오른쪽에서 열리는 사이드바인지
+ * @param clickEvent 완료하기 버튼을 눌렀을때 발생하는 이벤트 넣어주시면 됩니다
+ */
+
+export default function SideBar({
+  children,
+  trigger,
+  position,
+  clickEvent,
+}: SideBarProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const sideBarRef = useRef<HTMLDivElement>(null);
+
+  const toggleSideBar = () => {
+    setIsOpen(!isOpen);
+  };
+
+  //사이드바 밖 부분을 클릭시 닫기위한 로직
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        sideBarRef.current &&
+        !sideBarRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
+  const classes = {
+    sidebar: clsx(
+      'fixed h-auto transform bg-gray-800 text-white transition-transform',
+      {
+        'inset-y-0 left-0 w-52': position === 'left',
+        'bottom-0 right-0 top-[66px] min-w-[375px] border border-border-primary border-opacity-50':
+          position === 'right',
+        'translate-x-0': isOpen,
+        '-translate-x-full': !isOpen && position === 'left',
+        'translate-x-full': !isOpen && position === 'right',
+      }
+    ),
+
+    closeButton: clsx('absolute top-4', {
+      'right-4': position === 'left',
+      'left-4': position === 'right',
+    }),
+
+    completeButtonWrapper: clsx({
+      'fixed bottom-6 right-6': position === 'right',
+      hidden: position === 'left',
+    }),
+  };
+
+  return (
+    <>
+      {/* 메뉴를 여는 트리거 */}
+      {trigger(toggleSideBar)}
+
+      <div ref={sideBarRef} className={classes.sidebar}>
+        <button className={classes.closeButton} onClick={toggleSideBar}>
+          <XIcon />
+        </button>
+        <div className="mt-10">{children}</div>
+
+        <div className={classes.completeButtonWrapper}>
+          <Button shape="round">
+            <div
+              onClick={clickEvent}
+              className="flex items-center justify-center gap-1"
+            >
+              <CheckWhiteIcon />
+              <span>완료하기</span>
+            </div>
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,6 +11,7 @@ const config: Config = {
     extend: {
       screens: {
         tablet: '1024px',
+      },
       backgroundImage: {
         'brand-gradient': 'linear-gradient(#10B981, #A3E635)', // brand.gradient 정의된 값
       },


### PR DESCRIPTION
# 작업분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
- 공통 컴포넌트 sidebar 제작

# 작업 상세 내용
- children 사이드바 안의 컨텐츠 넣어주시면 됩니다
- trigger 사이드바를 여는 트리거로 사이드 바를 여는 버튼 혹은 글을 적용하면 됩니다.
- position 왼쪽에서 열리는 사이드바인지 오른쪽에서 열리는 사이드바인지
- clickEvent 완료하기 버튼을 눌렀을때 발생하는 이벤트 넣어주시면 됩니다

# 작업 스샷
- 팀페이지 모바일 사이즈 일떄 나오는 사이드바
![left1](https://github.com/user-attachments/assets/76421060-b233-41cd-b44f-3719ac3a6f95)

- 리스트 페이지 사이드바 -> 콘텐츠에 따라서 너비가 맞춰지게 만들었고, 안의 내용은 api 연결해서 넣을수 있도록 children으로 만들었습니다
![rigth2](https://github.com/user-attachments/assets/0d21cf7f-71ce-4d98-a5e5-4257438cd051)


# 리뷰 요구사항
- 사이드바가 두곳에서만 쓰이고 한곳은 모바일일때만 쓰다보니깐 안의 내용을  children올 했는데 이게 맞게 한건지..? 
- 코드상 이상한 부분이나 잘못된 부분있으면 피드백 부탁드립니다

# 연관된 Jira 티켓 번호
- ZERO-29 : https://fe08team4.atlassian.net/browse/ZERO-29?atlOrigin=eyJpIjoiODVkZWY5NDU0OTIyNDE3ZGFkNTkxZTI5MzAxNTQ0M2MiLCJwIjoiaiJ9
