### PR TITLE
ZERO-98:  프로필이미지 인풋 컴포넌트 추가

### DIFF
--- a/src/components/@shared/ProfileImageInput.tsx
+++ b/src/components/@shared/ProfileImageInput.tsx
@@ -1,0 +1,63 @@
+import ProfileEditIcon from 'public/icons/profile_edit.svg';
+import { useRef, useState } from 'react';
+
+interface ProfileImageInputProps {
+  onFileChange: (file: File) => void;
+}
+
+export default function ProfileImageInput({
+  onFileChange,
+}: ProfileImageInputProps) {
+  const [ProfileImage, setProfileImage] = useState<string | JSX.Element>(
+    <ProfileEditIcon />
+  );
+  const fileInput = useRef<HTMLInputElement | null>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      const file = e.target.files[0];
+
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (reader.readyState === 2 && reader.result) {
+          setProfileImage(
+            <img
+              src={reader.result as string}
+              alt="프로필 이미지"
+              className="h-16 w-16 rounded-full object-cover"
+            />
+          );
+        }
+      };
+      reader.readAsDataURL(file);
+
+      // 부모 컴포넌트에 파일 전달
+      onFileChange(file);
+    } else {
+      setProfileImage(<ProfileEditIcon />);
+    }
+  };
+
+  return (
+    <main className="mx-6 flex max-w-[792px] flex-col gap-6">
+      <div>
+        <input
+          type="file"
+          ref={fileInput}
+          style={{ display: 'none' }}
+          onChange={handleChange}
+        />
+        <button
+          type="button"
+          onClick={() => {
+            if (fileInput.current) {
+              fileInput.current.click();
+            }
+          }}
+        >
+          {ProfileImage}
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -9,6 +9,7 @@ import {
   ScrollTextArea,
   AutoTextArea,
 } from '@components/@shared/Input';
+import ProfileImageInput from '@components/@shared/ProfileImageInput';
 
 export default function Test() {
   const { isOpen, openModal, closeModal } = useModal();
@@ -33,6 +34,10 @@ export default function Test() {
     e.preventDefault();
     console.log('댓글 등록!:', text);
     setText('');
+  };
+
+  const handleFileChange = (imgFile: File) => {
+    console.log(imgFile);
   };
 
   return (
@@ -148,6 +153,7 @@ export default function Test() {
         placeholder="댓글을 달아주세요"
         onSubmit={handleSubmit}
       />
+      <ProfileImageInput onFileChange={handleFileChange} />
     </div>
   );
 }


### PR DESCRIPTION
# 작업분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
프로필이미지 인풋 컴포넌트 추가

# 작업 상세 내용
프로필 이미지 인풋 컴포넌트 제작
부모 요소에서 핸들러를 넣으면 file을 번환해줌
![2024-10-18 16;30;10](https://github.com/user-attachments/assets/951b51dd-9145-47dc-a70d-5302a6c03b3f)


# 리뷰 요구사항
api랑 연결을 안해서 어떻게 될 지는 모르겠지만.. 일단 의도대로 동작합니다!

# 연관된 Jira 티켓 번호
ZERO-98
