### PR TITLE
ZERO-61: 팀 생성하기 및 참여하기 페이지 API 연동

### DIFF
--- a/src/api/addteam/participateTeamAPI.ts
+++ b/src/api/addteam/participateTeamAPI.ts
@@ -1,0 +1,13 @@
+import { authAxiosInstance } from '@libs/axios/axiosInstance';
+
+// 팀 참여하기 API 함수
+export const postAcceptInvitation = async (
+  userEmail: string,
+  token: string
+) => {
+  const response = await authAxiosInstance.post('groups/accept-invitation', {
+    userEmail,
+    token,
+  });
+  return response.data;
+};

--- a/src/components/addteam/AddTeamForm.tsx
+++ b/src/components/addteam/AddTeamForm.tsx
@@ -12,8 +12,8 @@ export default function AddTeamForm() {
   const [teamProfileFile, setTeamProfileFile] = useState<File | null>(null);
   const router = useRouter();
 
-  // 그룹 생성 Mutation
-  const { mutate: createGroup } = useMutation({
+  // 팀 생성 Mutation
+  const { mutate: addTeam } = useMutation({
     mutationFn: ({ image, name }: { image: string; name: string }) =>
       postGroupById(image, name),
     onSuccess: (data) => {
@@ -27,7 +27,7 @@ export default function AddTeamForm() {
       }
     },
     onError: (error) => {
-      console.error('그룹 생성 실패:', error);
+      console.error('팀 생성 실패:', error);
     },
   });
 
@@ -36,7 +36,7 @@ export default function AddTeamForm() {
     mutationFn: (file: File) => postImage(file),
     onSuccess: (imageUrl: string) => {
       // 이미지 URL을 성공적으로 받으면 팀 생성 요청
-      createGroup({ image: imageUrl, name: teamName });
+      addTeam({ image: imageUrl, name: teamName });
     },
     onError: (error) => {
       console.error('이미지 업로드 실패:', error);

--- a/src/components/addteam/AddTeamForm.tsx
+++ b/src/components/addteam/AddTeamForm.tsx
@@ -1,14 +1,62 @@
+import { postImage } from '@/src/api/imageAPI';
+import { postGroupById } from '@/src/api/team/teamAPI';
 import Button from '@components/@shared/Button';
 import { Input } from '@components/@shared/Input';
 import ProfileImageInput from '@components/@shared/ProfileImageInput';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
 import { useState } from 'react';
 
 export default function AddTeamForm() {
-  const [teamProfile, setTeamProfile] = useState<File | null>(null);
+  const [teamName, setTeamName] = useState('');
+  const [teamProfileFile, setTeamProfileFile] = useState<File | null>(null);
+  const router = useRouter();
+
+  // 그룹 생성 Mutation
+  const { mutate: createGroup } = useMutation({
+    mutationFn: ({ image, name }: { image: string; name: string }) =>
+      postGroupById(image, name),
+    onSuccess: (data) => {
+      const teamId = data.id; // 팀 ID
+      setTeamName('');
+      setTeamProfileFile(null);
+      console.log(`${teamName}팀(아이디: ${teamId})이 생성되었습니다.`);
+      // 팀 생성 후 해당 팀 페이지로 리디렉트
+      if (teamId) {
+        router.push(`/${teamId}`);
+      }
+    },
+    onError: (error) => {
+      console.error('그룹 생성 실패:', error);
+    },
+  });
+
+  // 이미지 업로드 Mutation
+  const uploadImageMutate = useMutation({
+    mutationFn: (file: File) => postImage(file),
+    onSuccess: (imageUrl: string) => {
+      // 이미지 URL을 성공적으로 받으면 팀 생성 요청
+      createGroup({ image: imageUrl, name: teamName });
+    },
+    onError: (error) => {
+      console.error('이미지 업로드 실패:', error);
+    },
+  });
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTeamName(e.target.value);
+  };
 
   const handleFileChange = (file: File | null) => {
-    setTeamProfile(file);
-    console.log(teamProfile);
+    setTeamProfileFile(file);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (teamProfileFile && teamName) {
+      uploadImageMutate.mutate(teamProfileFile); // 이미지 업로드 시작
+    }
   };
 
   return (
@@ -20,10 +68,19 @@ export default function AddTeamForm() {
             <div className="mb-3 text-lg-medium">팀 프로필</div>
             <ProfileImageInput onFileChange={handleFileChange} />
           </div>
-          <Input label="팀 이름" placeholder="팀 이름을 입력해주세요." />
+          <Input
+            label="팀 이름"
+            placeholder="팀 이름을 입력해주세요."
+            inputProps={{
+              value: teamName,
+              onChange: handleNameChange,
+            }}
+          />
         </div>
       </div>
-      <Button size="full">생성하기</Button>
+      <Button size="full" onClick={handleSubmit}>
+        생성하기
+      </Button>
     </form>
   );
 }

--- a/src/components/addteam/ParticipateTeamForm.tsx
+++ b/src/components/addteam/ParticipateTeamForm.tsx
@@ -1,14 +1,65 @@
+import { postAcceptInvitation } from '@/src/api/addteam/participateTeamAPI';
 import Button from '@components/@shared/Button';
 import { Input } from '@components/@shared/Input';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
 
 export default function ParticipateTeamForm() {
+  const router = useRouter();
+  const [teamLink, setTeamLink] = useState('');
+
+  // 팀 참여 Mutation
+  const { mutate: participateTeam } = useMutation({
+    mutationFn: ({ userEmail, token }: { userEmail: string; token: string }) =>
+      postAcceptInvitation(userEmail, token),
+    onSuccess: (data) => {
+      const teamId = data.groupId; // 팀 ID
+      setTeamLink('');
+      console.log(`참여한 팀 아이디: ${teamId}`);
+      // 팀 참여 후 해당 팀 페이지로 리디렉트
+      if (teamId) {
+        router.push(`/${teamId}`);
+      }
+    },
+    onError: (error) => {
+      console.error('팀 참여 실패:', error);
+    },
+  });
+
+  const handleLinkChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTeamLink(e.target.value);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const userStorage = localStorage.getItem('userStorage');
+    if (userStorage) {
+      const parsedData = JSON.parse(userStorage);
+      const { email } = parsedData.state.user;
+      if (email && teamLink) {
+        participateTeam({ userEmail: email, token: teamLink }); // 팀 참여하기 시작
+      }
+    }
+  };
+
   return (
     <form className="flex w-[343px] flex-col gap-10 md:w-[460px]">
       <div className="flex w-[343px] flex-col items-center gap-6 md:w-[460px] md:gap-[80px]">
         <h1 className="text-2xl-medium xl:text-4xl">팀 참여하기</h1>
-        <Input label="팀 링크" placeholder="팀 링크를 입력해주세요." />
+        <Input
+          label="팀 링크"
+          placeholder="팀 링크를 입력해주세요."
+          inputProps={{
+            value: teamLink,
+            onChange: handleLinkChange,
+          }}
+        />
       </div>
-      <Button size="full">참여하기</Button>
+      <Button size="full" onClick={handleSubmit}>
+        참여하기
+      </Button>
     </form>
   );
 }


### PR DESCRIPTION
# 작업분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
팀 생성하기 페이지 API 연동
팀 참여하기 페이지 API 연동

# 작업 상세 내용
- 팀 생성하기 페이지에서 프로필과 이름을 입력 후 생성 버튼 누름 -> 생성이 완료되면 해당 팀 페이지로 이동
![스크린샷(118)](https://github.com/user-attachments/assets/e244f3b4-27ec-4154-90d2-effd2b4766d5)
![스크린샷(119)](https://github.com/user-attachments/assets/9dfad896-a413-441f-a122-28d1a86c317f)

- 팀 참여하기 페이지에서 링크(토큰)을 입력 후 참여 버튼 누름 -> 참여가 완료되면 해당 팀 페이지로 이동
![스크린샷(115)](https://github.com/user-attachments/assets/e3d80d70-b298-4341-ba48-3263eca49192)
![스크린샷(113)](https://github.com/user-attachments/assets/b63c6658-b4e8-416d-95cb-337303c79d1c)

# 리뷰 요구사항


# 연관된 Jira 티켓 번호
ZERO-61