### PR TITLE
ZERO-112 : 팀페이지 api연결 - 할일목록  (+멤버초대)

### DIFF
--- a/src/api/tasks/taskListAPI.ts
+++ b/src/api/tasks/taskListAPI.ts
@@ -1,9 +1,9 @@
-import { axiosInstance } from '@libs/axios/axiosInstance';
+import { authAxiosInstance } from '@libs/axios/axiosInstance';
 
 // 특정 날짜에 해당하는 할 일 목록
 // 날짜 기본 값 당일
 export const getTaskList = async (id: number, date: string) => {
-  const response = await axiosInstance.get(
+  const response = await authAxiosInstance.get(
     `groups/{groupId}/task-lists/${id}`,
     {
       params: { date },
@@ -12,21 +12,31 @@ export const getTaskList = async (id: number, date: string) => {
   return response.data;
 };
 
-export const patchTaskList = async (groupId: number, id: number) => {
-  const response = await axiosInstance.patch(
-    `groups/${groupId}/task-lists/${id}`
+export const patchTaskList = async (
+  groupId: number,
+  id: string,
+  name: string
+) => {
+  const response = await authAxiosInstance.patch(
+    `groups/${groupId}/task-lists/${id}`,
+    {
+      name,
+    }
   );
   return response.data;
 };
 
 export const deleteTaskList = async (id: number) => {
-  await axiosInstance.delete(`groups/{groupId}/task-lists/${id}`);
+  await authAxiosInstance.delete(`groups/{groupId}/task-lists/${id}`);
 };
 
 export const postTaskList = async (groupId: number, name: string) => {
-  const response = await axiosInstance.post(`groups/${groupId}/task-lists`, {
-    name,
-  });
+  const response = await authAxiosInstance.post(
+    `groups/${groupId}/task-lists`,
+    {
+      name,
+    }
+  );
   return response.data;
 };
 
@@ -35,7 +45,7 @@ export const patchTaskListOrder = async (
   id: number,
   displayIndex: number
 ) => {
-  const response = await axiosInstance.patch(
+  const response = await authAxiosInstance.patch(
     `groups/${groupId}/task-lists/${id}/order`,
     { displayIndex }
   );

--- a/src/api/team/memberAPI.ts
+++ b/src/api/team/memberAPI.ts
@@ -7,3 +7,9 @@ export const deleteMemberById = async (id: string, memberUserID: number) => {
   );
   return response.data;
 };
+
+// 초대용 토큰을 불러오는 API함수
+export const inviteMember = async (groupId: number) => {
+  const response = await authAxiosInstance.get(`groups/${groupId}/invitation`);
+  return response.data;
+};

--- a/src/components/team/Report.tsx
+++ b/src/components/team/Report.tsx
@@ -1,26 +1,11 @@
 import { useEffect, useState } from 'react';
+import { useTeamStore } from '@/src/stores/teamStore';
 import Image from 'next/image';
 import CircleGraph from './CircleGraph';
 
-export interface TaskProps {
-  name: string;
-  done: boolean;
-}
-export interface TaskListItem {
-  displayIndex: number;
-  groupId: number;
-  updatedAt: string;
-  createdAt: string;
-  name: string;
-  id: number;
-  tasks: TaskProps[];
-}
+export default function Report() {
+  const { taskLists } = useTeamStore();
 
-interface TaskListProps {
-  taskLists: TaskListItem[];
-}
-
-export default function Report({ taskLists }: TaskListProps) {
   const [totalTasks, setTotalTasks] = useState(0);
   const [doneTasks, setDoneTasks] = useState(0);
   const [doneRate, setDoneRate] = useState(0);
@@ -32,7 +17,7 @@ export default function Report({ taskLists }: TaskListProps) {
 
     taskLists.forEach((taskList) => {
       total += taskList.tasks.length;
-      done += taskList.tasks.filter((task) => task.done).length;
+      done += taskList.tasks.filter((task) => task.doneAt !== null).length;
       rate = total === 0 ? 0 : Math.round((done / total) * 100);
     });
 

--- a/src/components/team/banner/DeleteTeamModal.tsx
+++ b/src/components/team/banner/DeleteTeamModal.tsx
@@ -15,7 +15,7 @@ export default function DeleteTeamModal({
   isOpen,
   onClose,
 }: DeleteTeamModalProps) {
-  const { teamId } = useTeamStore();
+  const { id } = useTeamStore();
   const router = useRouter();
 
   // 그룹 삭제 Mutation
@@ -32,7 +32,7 @@ export default function DeleteTeamModal({
   });
 
   const handleDeleteClick = () => {
-    deleteGroup(teamId as string);
+    deleteGroup(id as string);
   };
 
   return (

--- a/src/components/team/banner/EditTeamModal.tsx
+++ b/src/components/team/banner/EditTeamModal.tsx
@@ -15,7 +15,7 @@ interface EditTeamModalProps {
 
 export default function EditTeamModal({ isOpen, onClose }: EditTeamModalProps) {
   const [imageFile, setImageFile] = useState<File | null>(null);
-  const { teamId, teamName, imageUrl, setTeamName } = useTeamStore();
+  const { id, teamName, imageUrl, setTeamName } = useTeamStore();
   // 모달 내부에서 관리할 임시 상태
   const [localTeamName, setLocalTeamName] = useState(teamName);
   const queryClient = useQueryClient();
@@ -32,14 +32,14 @@ export default function EditTeamModal({ isOpen, onClose }: EditTeamModalProps) {
   // 그룹 수정 Mutation
   const { mutate: editGroup } = useMutation({
     mutationFn: ({
-      id,
+      groupId,
       image,
       name,
     }: {
-      id: string;
+      groupId: string;
       image: string;
       name: string;
-    }) => patchGroupById(id, image, name),
+    }) => patchGroupById(groupId, image, name),
     onSuccess: () => {
       onClose();
       console.log(`${teamName} 팀 정보가 성공적으로 수정되었습니다.`);
@@ -47,7 +47,7 @@ export default function EditTeamModal({ isOpen, onClose }: EditTeamModalProps) {
 
     onSettled: () => {
       // 쿼리 무효화 및 리패치
-      queryClient.invalidateQueries({ queryKey: ['group', teamId] });
+      queryClient.invalidateQueries({ queryKey: ['group', id] });
     },
     onError: (error) => {
       console.error('그룹 생성 실패:', error);
@@ -59,7 +59,7 @@ export default function EditTeamModal({ isOpen, onClose }: EditTeamModalProps) {
     mutationFn: (file: File) => postImage(file),
     onSuccess: (imgUrl: string) => {
       // 이미지 URL을 성공적으로 받으면 그룹 수정 요청
-      editGroup({ id: teamId, image: imgUrl, name: localTeamName });
+      editGroup({ groupId: id, image: imgUrl, name: localTeamName });
     },
     onError: (error) => {
       console.error('이미지 업로드 실패:', error);
@@ -73,7 +73,7 @@ export default function EditTeamModal({ isOpen, onClose }: EditTeamModalProps) {
       uploadImageMutate.mutate(imageFile);
     } else {
       // 파일이 없으면 기존 URL로 그룹 수정
-      editGroup({ id: teamId, image: imageUrl, name: localTeamName });
+      editGroup({ groupId: id, image: imageUrl, name: localTeamName });
     }
   };
 

--- a/src/components/team/member/ExileUserModal.tsx
+++ b/src/components/team/member/ExileUserModal.tsx
@@ -31,7 +31,7 @@ interface Membership {
   group: Group;
 }
 
-interface UserData {
+export interface UserData {
   id: number;
   nickname: string;
   createdAt: string;

--- a/src/components/team/member/ExileUserModal.tsx
+++ b/src/components/team/member/ExileUserModal.tsx
@@ -48,7 +48,7 @@ export default function ExileUserModal({
   memberName,
   userId,
 }: ExileUserModalProps) {
-  const { teamId } = useTeamStore();
+  const { id } = useTeamStore();
   const queryClient = useQueryClient();
 
   // 'user' 키로 캐싱된 유저 데이터 가져오기
@@ -56,15 +56,15 @@ export default function ExileUserModal({
 
   // 멤버 삭제 Mutation
   const { mutate: deleteMember } = useMutation({
-    mutationFn: ({ id, userid }: { id: string; userid: number }) =>
-      deleteMemberById(id, userid),
+    mutationFn: ({ groupid, userid }: { groupid: string; userid: number }) =>
+      deleteMemberById(groupid, userid),
     onSuccess: () => {
       console.log('멤버 정보 삭제 완료!');
       onClose();
     },
     onSettled: () => {
       // 쿼리 무효화 및 리패치
-      queryClient.invalidateQueries({ queryKey: ['group', teamId] });
+      queryClient.invalidateQueries({ queryKey: ['group', id] });
     },
     onError: (error) => {
       console.error('멤버 삭제 실패:', error);
@@ -74,7 +74,7 @@ export default function ExileUserModal({
   // 팀 관리자만 삭제 가능
   const isAdmin =
     userData &&
-    userData.memberships.find((m) => m.groupId === Number(teamId))?.role ===
+    userData.memberships.find((m) => m.groupId === Number(id))?.role ===
       'ADMIN';
   // 본인 삭제 불가 체크
   const isSelf = userData && userData.id === userId;
@@ -90,7 +90,7 @@ export default function ExileUserModal({
       return;
     }
 
-    deleteMember({ id: teamId as string, userid: userId as number });
+    deleteMember({ groupid: id as string, userid: userId as number });
   };
 
   return (

--- a/src/components/team/member/InvitationModal.tsx
+++ b/src/components/team/member/InvitationModal.tsx
@@ -1,5 +1,8 @@
 import Button from '@components/@shared/Button';
 import { Modal } from '@components/@shared/Modal';
+import { inviteMember } from '@/src/api/team/memberAPI';
+import { useQuery } from '@tanstack/react-query';
+import { useTeamStore } from '@/src/stores/teamStore';
 
 interface InvitationModalProps {
   isOpen: boolean;
@@ -10,8 +13,22 @@ export default function InvitationModal({
   isOpen,
   onClose,
 }: InvitationModalProps) {
-  const handleCopyClick = () => {
-    console.log('클립보드에 복사 완료!');
+  const { id } = useTeamStore();
+
+  const { data } = useQuery({
+    queryKey: ['inviteMember', id],
+    queryFn: () => inviteMember(Number(id)),
+  });
+
+  const handleCopyClick = (text: string) => {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        console.log('복사한 토큰: ', data);
+      })
+      .catch((err) => {
+        console.error('복사에 실패했습니다!: ', err);
+      });
     onClose();
   };
 
@@ -34,7 +51,7 @@ export default function InvitationModal({
         </Modal.Content>
       </Modal.Wrapper>
       <Modal.Footer>
-        <Button size="full" onClick={handleCopyClick}>
+        <Button size="full" onClick={() => handleCopyClick(data)}>
           링크 복사하기
         </Button>
       </Modal.Footer>

--- a/src/components/team/taskList/AddTaskListModal.tsx
+++ b/src/components/team/taskList/AddTaskListModal.tsx
@@ -1,19 +1,50 @@
+import { postTaskList } from '@/src/api/tasks/taskListAPI';
 import Button from '@components/@shared/Button';
 import { Input } from '@components/@shared/Input';
 import { Modal } from '@components/@shared/Modal';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 
 interface AddTaskListModalProps {
   isOpen: boolean;
   onClose: () => void;
+  groupId: string;
 }
 
 export default function AddTaskListModal({
   isOpen,
   onClose,
+  groupId,
 }: AddTaskListModalProps) {
+  const [taskListName, setTaskListName] = useState('');
+  const newGroupId = Number(groupId);
+  const queryClient = useQueryClient();
+
+  // 그룹 생성 Mutation
+  const { mutate: createTaskList } = useMutation({
+    mutationFn: ({ id, name }: { id: number; name: string }) =>
+      postTaskList(id, name),
+    onSuccess: () => {
+      setTaskListName('');
+      onClose();
+    },
+    onSettled: () => {
+      // 쿼리 무효화 및 리패치
+      queryClient.invalidateQueries({ queryKey: ['group', groupId] });
+    },
+    onError: (error) => {
+      console.error('목록 생성 실패:', error);
+    },
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTaskListName(e.target.value);
+  };
+
   const handleAddClick = () => {
-    console.log('할 일 목록 추가 완료!');
-    onClose();
+    if (taskListName) {
+      createTaskList({ id: newGroupId, name: taskListName });
+    }
   };
 
   return (
@@ -31,7 +62,11 @@ export default function AddTaskListModal({
       <Modal.Wrapper array="column">
         <Modal.Header fontColor="primary">할 일 목록</Modal.Header>
         <Modal.Content fontColor="secondary" fontSize="14" fontArray="center">
-          <Input className="mt-[30px]" placeholder="목록 명을 입력해주세요." />
+          <Input
+            onChange={handleChange}
+            className="mt-[30px]"
+            placeholder="목록 명을 입력해주세요."
+          />
         </Modal.Content>
       </Modal.Wrapper>
       <Modal.Footer>

--- a/src/components/team/taskList/DeleteTaskListModal.tsx
+++ b/src/components/team/taskList/DeleteTaskListModal.tsx
@@ -1,21 +1,43 @@
+import { deleteTaskList } from '@/src/api/tasks/taskListAPI';
+import { useTeamStore } from '@/src/stores/teamStore';
 import Button from '@components/@shared/Button';
 import { Modal } from '@components/@shared/Modal';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 
 interface DeleteTaskListModalProps {
   isOpen: boolean;
   onClose: () => void;
+  taskListId: number;
   taskName: string;
 }
 
 export default function DeleteTaskListModal({
   isOpen,
   onClose,
+  taskListId,
   taskName,
 }: DeleteTaskListModalProps) {
+  const queryClient = useQueryClient();
+  const { id } = useTeamStore();
+
+  // 목록 삭제 Mutation
+  const { mutate: deleteList } = useMutation({
+    mutationFn: (id: number) => deleteTaskList(id),
+    onSuccess: () => {
+      onClose();
+    },
+    onSettled: () => {
+      // 쿼리 무효화 및 리패치
+      queryClient.invalidateQueries({ queryKey: ['group', id] });
+    },
+    onError: (error) => {
+      console.error('목록 삭제 실패:', error);
+    },
+  });
+
   const handleDeleteClick = () => {
-    console.log('할 일 목록 삭제 완료!');
-    onClose();
+    deleteList(taskListId);
   };
 
   return (

--- a/src/components/team/taskList/DeleteTaskListModal.tsx
+++ b/src/components/team/taskList/DeleteTaskListModal.tsx
@@ -4,6 +4,7 @@ import Button from '@components/@shared/Button';
 import { Modal } from '@components/@shared/Modal';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
+import { UserData } from '../member/ExileUserModal';
 
 interface DeleteTaskListModalProps {
   isOpen: boolean;
@@ -20,6 +21,14 @@ export default function DeleteTaskListModal({
 }: DeleteTaskListModalProps) {
   const queryClient = useQueryClient();
   const { id } = useTeamStore();
+  // 'user' 키로 캐싱된 유저 데이터 가져오기
+  const userData = queryClient.getQueryData<UserData>(['user']);
+
+  // 팀 관리자만 삭제 가능
+  const isAdmin =
+    userData &&
+    userData.memberships.find((m) => m.groupId === Number(id))?.role ===
+      'ADMIN';
 
   // 목록 삭제 Mutation
   const { mutate: deleteList } = useMutation({
@@ -37,6 +46,10 @@ export default function DeleteTaskListModal({
   });
 
   const handleDeleteClick = () => {
+    // 팀 관리자만 삭제 가능
+    if (!isAdmin) {
+      return;
+    }
     deleteList(taskListId);
   };
 
@@ -63,12 +76,22 @@ export default function DeleteTaskListModal({
             width={24}
             height={24}
           />
-          목록을 삭제하시겠어요?
+          {isAdmin ? (
+            <span>목록을 삭제하시겠어요?</span>
+          ) : (
+            <span>권한 없음</span>
+          )}
         </Modal.Header>
         <Modal.Content fontColor="secondary" fontSize="14" fontArray="center">
-          <p className="mt-[20px]">
-            [{taskName}] 내의 모든 할 일이 사라집니다. 정말로 삭제하시겠습니까?
-          </p>
+          {isAdmin && (
+            <p className="mt-[20px]">
+              [{taskName}] 내의 모든 할 일이 사라집니다. 정말로
+              삭제하시겠습니까?
+            </p>
+          )}
+          {!isAdmin && (
+            <p className="mt-[20px]">관리자만 삭제할 수 있습니다.</p>
+          )}
         </Modal.Content>
       </Modal.Wrapper>
       <Modal.Footer>
@@ -81,9 +104,11 @@ export default function DeleteTaskListModal({
           >
             취소
           </Button>
-          <Button size="full" bgColor="red" onClick={handleDeleteClick}>
-            삭제
-          </Button>
+          {isAdmin && (
+            <Button size="full" bgColor="red" onClick={handleDeleteClick}>
+              삭제
+            </Button>
+          )}
         </div>
       </Modal.Footer>
     </Modal>

--- a/src/components/team/taskList/EditTaskListModal.tsx
+++ b/src/components/team/taskList/EditTaskListModal.tsx
@@ -1,30 +1,29 @@
+import { patchTaskList } from '@/src/api/tasks/taskListAPI';
+import { useTeamStore } from '@/src/stores/teamStore';
 import Button from '@components/@shared/Button';
 import { Input } from '@components/@shared/Input';
 import { Modal } from '@components/@shared/Modal';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 
 interface EditTaskListModalProps {
   isOpen: boolean;
   onClose: () => void;
   initialTaskListName?: string;
+  taskListId: number;
 }
 
 export default function EditTaskListModal({
   isOpen,
   onClose,
   initialTaskListName = '',
+  taskListId,
 }: EditTaskListModalProps) {
   const [TaskListName, setTaskListName] = useState(initialTaskListName);
+  const { id } = useTeamStore();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTaskListName(e.target.value);
-  };
-
-  const handleEditClick = () => {
-    setTaskListName(initialTaskListName);
-    onClose();
-    console.log('목록 이름', TaskListName, '으로 변경!');
-    // API요청 추가 예정
   };
 
   // 모달이 닫힐 때 TaskListName을 초기값으로 리셋
@@ -33,6 +32,41 @@ export default function EditTaskListModal({
       setTaskListName(initialTaskListName);
     }
   }, [isOpen, initialTaskListName]);
+
+  const queryClient = useQueryClient();
+
+  // 할 일 목록 수정 Mutation
+  const { mutate: editGroup } = useMutation({
+    mutationFn: ({
+      groupId,
+      taskListId,
+      name,
+    }: {
+      groupId: number;
+      taskListId: string;
+      name: string;
+    }) => patchTaskList(groupId, taskListId, name),
+    onSuccess: () => {
+      onClose();
+      console.log(`${TaskListName} 팀 정보가 성공적으로 수정되었습니다.`);
+    },
+
+    onSettled: () => {
+      // 쿼리 무효화 및 리패치
+      queryClient.invalidateQueries({ queryKey: ['group', id] });
+    },
+    onError: (error) => {
+      console.error('그룹 생성 실패:', error);
+    },
+  });
+
+  const handlePatchClick = () => {
+    editGroup({
+      groupId: Number(id),
+      taskListId: String(taskListId),
+      name: TaskListName,
+    });
+  };
 
   return (
     <Modal
@@ -59,7 +93,7 @@ export default function EditTaskListModal({
       />
 
       <Modal.Footer>
-        <Button size="full" onClick={handleEditClick}>
+        <Button size="full" onClick={handlePatchClick}>
           수정하기
         </Button>
       </Modal.Footer>

--- a/src/components/team/taskList/TaskBar.tsx
+++ b/src/components/team/taskList/TaskBar.tsx
@@ -1,28 +1,23 @@
 import { useModal } from '@hooks/useModal';
 import { Option } from '@components/@shared/Dropdown';
+import { TaskProps, useTeamStore } from '@/src/stores/teamStore';
 import Image from 'next/image';
 import CircleGraph from '../CircleGraph';
 import EditDropdown from '../EditDropdown';
 import DeleteTaskListModal from './DeleteTaskListModal';
 import EditTaskListModal from './EditTaskListModal';
 
-export interface TaskProps {
-  name: string;
-  done: boolean;
-}
-
 interface TaskBarProps {
   name: string;
   tasks: TaskProps[];
+  id: number;
 }
 
-export default function TaskBar({ name, tasks }: TaskBarProps) {
+export default function TaskBar({ name, tasks, id }: TaskBarProps) {
   // 1. 총 task의 개수
   const totalTasks = tasks.length;
-
-  // 2. done이 true인 task의 개수
-  const doneTasksCount = tasks.filter((task) => task.done).length;
-
+  // 2. doneAt이 null이 아닌 task의 개수
+  const doneTasksCount = tasks.filter((task) => task.doneAt !== null).length;
   // 3. 진척도
   const doneRate = totalTasks === 0 ? 0 : (doneTasksCount / totalTasks) * 100;
 
@@ -94,10 +89,12 @@ export default function TaskBar({ name, tasks }: TaskBarProps) {
           isOpen={editListIsOpen}
           onClose={editListCloseModal}
           initialTaskListName={name}
+          taskListId={id}
         />
         <DeleteTaskListModal
           isOpen={deleteListIsOpen}
           onClose={deleteListCloseModal}
+          taskListId={id}
           taskName={name}
         />
       </div>

--- a/src/components/team/taskList/TaskList.tsx
+++ b/src/components/team/taskList/TaskList.tsx
@@ -1,31 +1,16 @@
 import { useModal } from '@hooks/useModal';
+import { useTeamStore } from '@/src/stores/teamStore';
 import TaskBar from './TaskBar';
 import AddTaskListModal from './AddTaskListModal';
 
-export interface TaskProps {
-  name: string;
-  done: boolean;
-}
-export interface TaskListItem {
-  displayIndex: number;
-  groupId: number;
-  updatedAt: string;
-  createdAt: string;
-  name: string;
-  id: number;
-  tasks: TaskProps[];
-}
-
-interface TaskListProps {
-  taskLists: TaskListItem[];
-}
-
-export default function TaskList({ taskLists }: TaskListProps) {
+export default function TaskList() {
   const {
     isOpen: addListIsOpen,
     onOpen: addListOpenModal,
     onClose: addListCloseModal,
   } = useModal();
+
+  const { taskLists, id } = useTeamStore();
 
   const listCount = taskLists.length;
 
@@ -47,6 +32,7 @@ export default function TaskList({ taskLists }: TaskListProps) {
           <AddTaskListModal
             isOpen={addListIsOpen}
             onClose={addListCloseModal}
+            groupId={id}
           />
         </div>
       </div>
@@ -56,6 +42,7 @@ export default function TaskList({ taskLists }: TaskListProps) {
             key={taskList.id}
             name={taskList.name}
             tasks={taskList.tasks}
+            id={taskList.id}
           />
         ))}
       </div>

--- a/src/components/team/taskList/TaskList.tsx
+++ b/src/components/team/taskList/TaskList.tsx
@@ -36,6 +36,11 @@ export default function TaskList() {
           />
         </div>
       </div>
+      {listCount === 0 && (
+        <p className="my-[100px] text-center text-md-medium text-text-default">
+          아직 할 일 목록이 없습니다.
+        </p>
+      )}
       <div className="flex flex-col gap-[10px]">
         {taskLists.map((taskList) => (
           <TaskBar

--- a/src/pages/[teamid]/index.tsx
+++ b/src/pages/[teamid]/index.tsx
@@ -31,7 +31,7 @@ export default function TeamPage() {
   if (isError) return <div>Error loading data</div>;
 
   return (
-    <main className="mx-auto mt-[20px] w-full min-w-[340px] px-[10px] xl:w-[1200px] xl:px-0">
+    <main className="mx-auto mb-[30px] mt-[20px] w-full min-w-[340px] px-[10px] xl:w-[1200px] xl:px-0">
       <TeamBanner />
       <TaskList />
       <Report />

--- a/src/pages/[teamid]/index.tsx
+++ b/src/pages/[teamid]/index.tsx
@@ -8,41 +8,6 @@ import MemberList from '@components/team/member/MemberList';
 import { useTeamStore } from '@/src/stores/teamStore';
 import { useEffect } from 'react';
 
-export interface MemberProps {
-  role: string;
-  userImage: string;
-  userEmail: string;
-  userName: string;
-  groupId: number;
-  userId: number;
-}
-
-export interface TaskProps {
-  name: string;
-  done: boolean;
-}
-
-export interface TaskListProps {
-  displayIndex: number;
-  groupId: number;
-  updatedAt: string;
-  createdAt: string;
-  name: string;
-  id: number;
-  tasks: TaskProps[];
-}
-
-export interface TeamDataProps {
-  teamId: string;
-  updatedAt: string;
-  createdAt: string;
-  image: string;
-  name: string;
-  id: number;
-  members: MemberProps[];
-  taskLists: TaskListProps[];
-}
-
 export default function TeamPage() {
   const router = useRouter();
   const { teamid } = router.query;
@@ -53,7 +18,6 @@ export default function TeamPage() {
     queryKey: ['group', teamIdString],
     queryFn: () => getGroupById(teamIdString as string),
   });
-
   const { setTeamData } = useTeamStore();
 
   useEffect(() => {
@@ -69,9 +33,9 @@ export default function TeamPage() {
   return (
     <main className="mx-auto mt-[20px] w-full min-w-[340px] px-[10px] xl:w-[1200px] xl:px-0">
       <TeamBanner />
-      <TaskList taskLists={data?.taskLists} />
-      <Report taskLists={data?.taskLists} />
-      <MemberList members={data?.members} />
+      <TaskList />
+      <Report />
+      <MemberList />
     </main>
   );
 }

--- a/src/stores/teamStore.ts
+++ b/src/stores/teamStore.ts
@@ -10,9 +10,37 @@ export interface MemberProps {
   userId: number;
 }
 
+export interface User {
+  id: number;
+  nickname: string;
+  image: string | null;
+}
+
+export interface DoneBy {
+  user: User | null;
+}
+
+export interface Writer {
+  id: number;
+  nickname: string;
+  image: string | null;
+}
+
 export interface TaskProps {
+  id: number;
   name: string;
-  done: boolean;
+  description: string;
+  date: string; // ISO 8601 형식
+  doneAt: string | null; // ISO 8601 형식
+  updatedAt: string; // ISO 8601 형식
+  user: User | null; // 태스크에 할당된 사용자
+  recurringId: number;
+  deletedAt: string | null; // 삭제된 날짜, null일 경우 삭제되지 않음
+  displayIndex: number; // 표시 순서
+  writer: Writer; // 태스크 작성자
+  doneBy: DoneBy; // 완료한 사용자
+  commentCount: number; // 댓글 수
+  frequency: string; // 반복 주기 ('ONCE' 등)
 }
 
 export interface TaskListProps {
@@ -37,7 +65,7 @@ export interface TeamDataProps {
 }
 
 interface TeamStore {
-  teamId: string;
+  id: string;
   teamName: string;
   imageUrl: string;
   members: MemberProps[];
@@ -51,14 +79,14 @@ interface TeamStore {
 }
 
 export const useTeamStore = create<TeamStore>((set) => ({
-  teamId: '0',
+  id: '0',
   teamName: '',
   imageUrl: '',
   members: [],
   taskLists: [],
   setTeamData: (data) =>
     set({
-      teamId: data.id.toString(),
+      id: data.id.toString(),
       teamName: data.name,
       imageUrl: data.image,
       members: data.members,
@@ -70,7 +98,7 @@ export const useTeamStore = create<TeamStore>((set) => ({
   setTaskLists: (taskLists) => set({ taskLists }),
   clearTeamData: () =>
     set({
-      teamId: '0',
+      id: '0',
       teamName: '',
       imageUrl: '',
       members: [],


### PR DESCRIPTION
# 작업분류
- [ ] 버그 수정
- [x] 신규 기능
- [x] 리팩토링
- [ ] 기타

# 작업개요
 팀페이지 api연결 - 할일목록

# 작업 상세 내용
할 일 목록 추가, 수정, 삭제 기능 구현
관리자만 목록 삭제할 수 있도록 구현
실제 데이터와 리포트 그래프 연결

1. 관리자 권한

![2024-10-24 23;46;39](https://github.com/user-attachments/assets/a5646d1e-ccdd-4b42-9990-2109536809da)

2. 멤버 권한

![스크린샷 2024-10-24 235659](https://github.com/user-attachments/assets/c21a5269-0371-4c97-b70e-7c76804518de)

3. 멤버 초대 기능

![2024-10-25 00;19;07](https://github.com/user-attachments/assets/53a64b89-5c3b-499f-9982-28cf3f48c481)

4. 할 일 목록이 없을 때

![image](https://github.com/user-attachments/assets/69b3708e-d102-42f3-8497-16b42ff7a0f6)



# 리뷰 요구사항
멤버 초대 기능은 사실 다른 브랜치지만.. 너무 짧아서 같이 넣었습니다

# 연관된 Jira 티켓 번호
ZERO-112
