### PR TITLE
ZERO-136 : 팀페이지 할일목록 색상 추가 (+navbar 수정)

### DIFF
--- a/src/components/@shared/Dropdown.tsx
+++ b/src/components/@shared/Dropdown.tsx
@@ -8,6 +8,7 @@ import React, {
 
 export interface Option {
   label?: string;
+  id?: number;
   component: ReactNode;
 }
 

--- a/src/components/@shared/Dropdown.tsx
+++ b/src/components/@shared/Dropdown.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import styles from '../../styles/scroll.module.css';
 
 export interface Option {
   label?: string;
@@ -94,7 +95,7 @@ export default function Dropdown({
       {isOpen && (
         <div
           ref={dropdownRef}
-          className={`${optionsWrapClass} absolute z-50 flex flex-col bg-background-secondary text-text-primary`}
+          className={`${optionsWrapClass} absolute z-50 flex max-h-[200px] flex-col overflow-y-auto bg-background-secondary text-text-primary ${styles.dropdownScroll}`}
         >
           {options.map((option) => (
             <button

--- a/src/components/@shared/NavBar.tsx
+++ b/src/components/@shared/NavBar.tsx
@@ -34,6 +34,7 @@ export default function NavBar() {
         <button
           type="button"
           onClick={() => router.push(`/myhistory/${data?.id}`)}
+          className="w-full"
         >
           마이 히스토리
         </button>
@@ -45,6 +46,7 @@ export default function NavBar() {
         <button
           type="button"
           onClick={() => router.push(`/mysetting/${data?.id}`)}
+          className="w-full"
         >
           계정 설정
         </button>
@@ -53,7 +55,11 @@ export default function NavBar() {
     {
       label: '팀 참여',
       component: (
-        <button type="button" onClick={() => router.push('#')}>
+        <button
+          type="button"
+          onClick={() => router.push('/addteam/participate')}
+          className="w-full"
+        >
           팀 참여
         </button>
       ),
@@ -61,7 +67,11 @@ export default function NavBar() {
     {
       label: '전체 팀 리스트',
       component: (
-        <button type="button" onClick={() => router.push('myteam')}>
+        <button
+          type="button"
+          onClick={() => router.push('/myteam')}
+          className="w-full"
+        >
           전체 팀 리스트
         </button>
       ),
@@ -69,7 +79,7 @@ export default function NavBar() {
     {
       label: '로그아웃',
       component: (
-        <button type="button" onClick={handleLogout}>
+        <button type="button" onClick={handleLogout} className="w-full">
           로그아웃
         </button>
       ),

--- a/src/components/@shared/NavBar_Team.tsx
+++ b/src/components/@shared/NavBar_Team.tsx
@@ -1,5 +1,4 @@
 import ArrowDown from 'public/icons/arrow_down.svg';
-import KebabIcon from 'public/icons/kebab_small.svg';
 import { useModal } from '@hooks/useModal';
 import AddTeamModal from '@components/team/AddTeamModal';
 import { useRouter } from 'next/router';
@@ -10,15 +9,17 @@ import Dropdown, { Option } from '@components/@shared/Dropdown';
 import { User } from '@/src/types/mysetting/settingData';
 import Menu from 'public/icons/menu.svg';
 import Link from 'next/link';
-import EditTeamModal from '@components/team/banner/EditTeamModal';
-import DeleteTeamModal from '@components/team/banner/DeleteTeamModal';
 import Button from './Button';
+import SideBar from './SideBar';
+import { useTeamStore } from '@/src/stores/teamStore';
 
 export default function NavBarTeam({ data }: { data: User }) {
   const [selectedTeam, setSelectedTeam] = useState<Option | null>(null);
   const [isLogoOnlyPage, setIsLogoOnlyPage] = useState(false);
   const [isClient, setIsClient] = useState(false);
+  const [isLeftOpen, setIsLeftOpen] = useState(false);
   const router = useRouter();
+  const { id } = useTeamStore();
 
   const {
     isOpen: addIsOpen,
@@ -26,89 +27,47 @@ export default function NavBarTeam({ data }: { data: User }) {
     onClose: addCloseModal,
   } = useModal();
 
-  const {
-    isOpen: editIsOpen,
-    onOpen: editOpenModal,
-    onClose: editCloseModal,
-  } = useModal();
-
-  const {
-    isOpen: deleteIsOpen,
-    onOpen: deleteOpenModal,
-    onClose: deleteCloseModal,
-  } = useModal();
-
-  const handleTeamSelet = (groupId: number) => {
+  const handleTeamSelect = (groupId: number) => {
     router.push(`/${groupId}`);
+    setIsLeftOpen(false);
   };
+
+  const [teamArray, setTeamArray] = useState<Team[]>([]);
 
   useEffect(() => {
-    setIsClient(true);
-    const logoOnlyPages = ['/signin', 'signup', 'addteam', '/'];
-    // 팀참여하기 페이지, 비밀번호 재설정페이지 추가 필요
-    setIsLogoOnlyPage(logoOnlyPages.includes(router.pathname));
-  }, [router.pathname]);
+    if (data) {
+      // teamArray를 data로부터 업데이트
+      const updatedTeamArray = data.memberships.map((membership) => ({
+        id: membership.groupId,
+        name: membership.group.name || '',
+        image: membership.group.image,
+      }));
 
-  if (!isClient) {
-    return null;
-  }
-
-  const handleSelect = (option: Option) => {
-    if (option.label === '수정하기') {
-      editOpenModal(); // '수정하기'를 선택했을 때
-    } else {
-      deleteOpenModal();
-    } // '삭제하기'를 선택했을 때
-  };
-
-  const basic: Option[] = [
-    {
-      label: '수정하기',
-      component: (
-        <div
-          onClick={() => handleSelect({ label: '수정하기', component: null })}
-        >
-          수정하기
-        </div>
-      ),
-    },
-    {
-      label: '삭제하기',
-      component: (
-        <div
-          onClick={() => handleSelect({ label: '삭제하기', component: null })}
-        >
-          삭제하기
-        </div>
-      ),
-    },
-  ];
+      setTeamArray(updatedTeamArray); // 상태 업데이트
+    }
+  }, [data]); // data가 변경될 때마다 실행
 
   const teams: Option[] = [
     ...(data?.memberships?.map((membership) => ({
       label: membership.group.name || '',
+      id: membership.group.id,
       component: (
-        <div className=" flex items-center justify-between">
-          <div
-            className="flex items-center gap-3"
-            onClick={() => handleTeamSelet(membership.groupId)}
-          >
-            <Image
-              src={membership.group.image}
-              alt="팀 이미지"
-              width={30}
-              height={30}
-              className="rounded-md"
-            />
-            {membership.group.name}
-          </div>
-          <div className="relative">
-            <Dropdown
-              options={basic}
-              triggerIcon={<KebabIcon />}
-              optionsWrapClass="absolute w-[120px] md:w-[135px] left-[20px] top-[0px] mt-2 right-0 rounded-[12px] border border-background-tertiary"
-              optionClass="rounded-[12px] md:w-[135px] md:h-[47px] w-[120px] h-[40px] justify-center text-md-regular md:text-lg-regular text-center hover:bg-background-tertiary"
-            />
+        <div
+          className="flex items-center justify-between overflow-hidden "
+          onClick={() => handleTeamSelect(membership.groupId)}
+        >
+          <div className="flex items-center justify-between gap-3 overflow-hidden text-ellipsis whitespace-nowrap">
+            <div className="v relative h-[30px] w-[30px] shrink-0">
+              <Image
+                src={membership.group.image}
+                alt="팀 이미지"
+                fill
+                className="rounded-md object-cover"
+              />
+            </div>
+            <p className="overflow-hidden text-ellipsis whitespace-nowrap">
+              {membership.group.name}
+            </p>
           </div>
         </div>
       ),
@@ -123,26 +82,115 @@ export default function NavBarTeam({ data }: { data: User }) {
     },
   ];
 
+  // teams 배열을 useEffect로 설정
+  useEffect(() => {
+    // 현재 ID에 해당하는 팀을 찾습니다.
+    const currentTeam = teams.find((team) => team.id === Number(id));
+
+    // 팀이 존재하면 selectedTeam 상태를 업데이트합니다.
+    if (currentTeam) {
+      setSelectedTeam(currentTeam);
+    }
+  }, [id, teams]); // teams 배열이 변할 때마다 effect가 실행됩니다.
+
+  useEffect(() => {
+    setIsClient(true);
+    const logoOnlyPages = ['/signin', 'signup', 'addteam', '/'];
+    // 팀참여하기 페이지, 비밀번호 재설정페이지 추가 필요
+    setIsLogoOnlyPage(logoOnlyPages.includes(router.pathname));
+  }, [router.pathname]);
+
+  if (!isClient) {
+    return null;
+  }
+
+  interface Team {
+    id: number;
+    name: string;
+  }
+
+  // 단순히 image와 name을 표시하는 TeamItem 컴포넌트
+  function TeamItem({
+    id,
+    name,
+    isActive,
+  }: {
+    id: number;
+    name: string;
+    isActive: boolean;
+  }) {
+    return (
+      <div
+        onClick={() => handleTeamSelect(id)}
+        className="flex h-[40px] cursor-pointer items-center gap-3 overflow-hidden rounded-[12px] px-[16px] hover:bg-[#ffffff17]"
+      >
+        <p
+          className={`overflow-hidden text-ellipsis whitespace-nowrap ${isActive ? 'text-brand-primary' : ''}`}
+        >
+          {name}
+        </p>
+      </div>
+    );
+  }
+
   const handleSelectTeam = (option: Option) => {
     if (option.label === '팀 메뉴') {
       addOpenModal();
     } else {
-      setSelectedTeam(option);
+      // 현재 팀 ID와 선택한 팀의 ID가 다를 경우에만 상태 업데이트
+      if (option.id !== Number(id)) {
+        setSelectedTeam(option);
+      }
     }
+  };
+
+  const handleAddTeam = () => {
+    addOpenModal();
+    setIsLeftOpen(false);
   };
 
   return (
     <>
       <div className="md:hidden">
-        <Dropdown
-          options={teams}
-          selected={selectedTeam}
-          onSelect={handleSelectTeam}
-          triggerClass="flex gap-[12px] items-center text-text-primary"
-          triggerIcon={<Menu />}
-          optionsWrapClass="mt-[30px] flex p-[16px] rounded-[12px]"
-          optionClass="px[8px] py-[7px] rounded-[8px] w-[186px] h-[46px] hover:bg-background-tertiary"
-        />
+        <Menu
+          type="button"
+          className="cursor-pointer text-red-50"
+          onClick={() => setIsLeftOpen(true)}
+        >
+          왼쪽 사이드바 열기
+        </Menu>
+
+        <SideBar
+          position="left"
+          isOpen={isLeftOpen}
+          onClose={() => setIsLeftOpen(false)}
+        >
+          <nav>
+            <div className="flex flex-col gap-[5px] px-[10px]">
+              {teamArray.map((team) => (
+                <>
+                  <TeamItem
+                    id={team.id}
+                    key={team.id}
+                    name={team.name}
+                    isActive={team.id === Number(id)}
+                  />
+                </>
+              ))}
+              <Button
+                bgColor="transparent"
+                border="white"
+                size="full"
+                height={40}
+                fontSize="14"
+                onClick={handleAddTeam}
+                className="mt-[10px]"
+              >
+                + 팀 추가하기
+              </Button>
+            </div>
+          </nav>
+        </SideBar>
       </div>
       <Link href="/">
         <div className="block max-xl:hidden">
@@ -170,8 +218,6 @@ export default function NavBarTeam({ data }: { data: User }) {
           <Link href="/article">
             <span className="max-md:hidden">자유게시판</span>
           </Link>
-          <EditTeamModal isOpen={editIsOpen} onClose={editCloseModal} />
-          <DeleteTeamModal isOpen={deleteIsOpen} onClose={deleteCloseModal} />
         </>
       )}
     </>

--- a/src/components/@shared/NavBar_Team.tsx
+++ b/src/components/@shared/NavBar_Team.tsx
@@ -3,7 +3,7 @@ import { useModal } from '@hooks/useModal';
 import AddTeamModal from '@components/team/AddTeamModal';
 import { useRouter } from 'next/router';
 import PCLogo from 'public/images/logo_pc.png';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Image from 'next/image';
 import Dropdown, { Option } from '@components/@shared/Dropdown';
 import { User } from '@/src/types/mysetting/settingData';
@@ -47,41 +47,42 @@ export default function NavBarTeam({ data }: { data: User }) {
     }
   }, [data]); // data가 변경될 때마다 실행
 
-  const teams: Option[] = [
-    ...(data?.memberships?.map((membership) => ({
-      label: membership.group.name || '',
-      id: membership.group.id,
-      component: (
-        <div
-          className="flex items-center justify-between overflow-hidden "
-          onClick={() => handleTeamSelect(membership.groupId)}
-        >
-          <div className="flex items-center justify-between gap-3 overflow-hidden text-ellipsis whitespace-nowrap">
-            <div className="v relative h-[30px] w-[30px] shrink-0">
-              <Image
-                src={membership.group.image}
-                alt="팀 이미지"
-                fill
-                className="rounded-md object-cover"
-              />
+  const teams: Option[] = useMemo(() => {
+    return [
+      ...(data?.memberships?.map((membership) => ({
+        label: membership.group.name || '',
+        id: membership.group.id,
+        component: (
+          <div
+            className="flex items-center justify-between overflow-hidden "
+            onClick={() => handleTeamSelect(membership.groupId)}
+          >
+            <div className="flex items-center justify-between gap-3 overflow-hidden text-ellipsis whitespace-nowrap">
+              <div className="v relative h-[30px] w-[30px] shrink-0">
+                <Image
+                  src={membership.group.image}
+                  alt="팀 이미지"
+                  fill
+                  className="rounded-md object-cover"
+                />
+              </div>
+              <p className="overflow-hidden text-ellipsis whitespace-nowrap">
+                {membership.group.name}
+              </p>
             </div>
-            <p className="overflow-hidden text-ellipsis whitespace-nowrap">
-              {membership.group.name}
-            </p>
           </div>
-        </div>
-      ),
-    })) || []),
-    {
-      label: '팀 메뉴',
-      component: (
-        <Button bgColor="transparent" border="white" size="full" height={40}>
-          + 팀 추가하기
-        </Button>
-      ),
-    },
-  ];
-
+        ),
+      })) || []),
+      {
+        label: '팀 메뉴',
+        component: (
+          <Button bgColor="transparent" border="white" size="full" height={40}>
+            + 팀 추가하기
+          </Button>
+        ),
+      },
+    ];
+  }, [data]);
   // teams 배열을 useEffect로 설정
   useEffect(() => {
     // 현재 ID에 해당하는 팀을 찾습니다.

--- a/src/components/@shared/SideBar.tsx
+++ b/src/components/@shared/SideBar.tsx
@@ -58,7 +58,7 @@ export default function SideBar({
 
   const classes = {
     sidebar: clsx(
-      'fixed h-auto transform bg-gray-800 text-white transition-transform',
+      'fixed z-20 h-auto transform overflow-y-auto bg-gray-800 text-white transition-transform',
       {
         'inset-y-0 left-0 w-52': position === 'left',
         'bottom-0 right-0 top-[66px] min-w-[375px] border border-border-primary border-opacity-10':
@@ -82,9 +82,11 @@ export default function SideBar({
 
   return (
     <div ref={sideBarRef} className={classes.sidebar}>
-      <button type="button" className={classes.closeButton} onClick={onClose}>
-        <XIcon />
-      </button>
+      <div className="sticky top-0">
+        <button type="button" className={classes.closeButton} onClick={onClose}>
+          <XIcon />
+        </button>
+      </div>
       <div className="mt-10">{children}</div>
       <div className={classes.completeButtonWrapper}>
         {button === 'completebutton' ? (

--- a/src/components/@shared/SideBar.tsx
+++ b/src/components/@shared/SideBar.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import Button from '@components/@shared/Button';
 import CheckWhiteIcon from 'public/icons/check_white.svg';
 import CheckGreenIcon from 'public/icons/check_green.svg';
+import styles from '../../styles/scroll.module.css';
 
 interface SideBarProps {
   children: ReactNode;
@@ -58,7 +59,7 @@ export default function SideBar({
 
   const classes = {
     sidebar: clsx(
-      'fixed z-20 h-auto transform overflow-y-auto bg-gray-800 text-white transition-transform',
+      'fixed z-20 h-auto transform overflow-y-auto bg-gray-800 text-white transition-transform ',
       {
         'inset-y-0 left-0 w-52': position === 'left',
         'bottom-0 right-0 top-[66px] min-w-[375px] border border-border-primary border-opacity-10':
@@ -81,13 +82,16 @@ export default function SideBar({
   };
 
   return (
-    <div ref={sideBarRef} className={classes.sidebar}>
+    <div
+      ref={sideBarRef}
+      className={`${classes.sidebar} ${styles.sidebarScroll}`}
+    >
       <div className="sticky top-0">
         <button type="button" className={classes.closeButton} onClick={onClose}>
           <XIcon />
         </button>
       </div>
-      <div className="mt-10">{children}</div>
+      <div className={`mt-10 h-full`}>{children}</div>
       <div className={classes.completeButtonWrapper}>
         {button === 'completebutton' ? (
           <Button width={138} height={40} shape="round">

--- a/src/components/team/AddTeamModal.tsx
+++ b/src/components/team/AddTeamModal.tsx
@@ -52,6 +52,10 @@ export default function AddTeamModal({ isOpen, onClose }: AddTeamModalProps) {
         router.push(`/${groupId}`); // 해당 그룹 페이지로 리다이렉트
       }
     },
+    onSettled: () => {
+      // 쿼리 무효화 및 리패치
+      queryClient.invalidateQueries({ queryKey: ['user'] });
+    },
     onError: (error) => {
       console.error('그룹 생성 실패:', error);
     },
@@ -66,6 +70,10 @@ export default function AddTeamModal({ isOpen, onClose }: AddTeamModalProps) {
       if (validateValueOnSubmit('teamName', TeamNames, teamName)) {
         createGroup({ image: imageUrl, name: teamName });
       }
+    },
+    onSettled: () => {
+      // 쿼리 무효화 및 리패치
+      queryClient.invalidateQueries({ queryKey: ['user'] });
     },
     onError: (error) => {
       console.error('이미지 업로드 실패:', error);

--- a/src/components/team/banner/EditTeamModal.tsx
+++ b/src/components/team/banner/EditTeamModal.tsx
@@ -78,7 +78,9 @@ export default function EditTeamModal({ isOpen, onClose }: EditTeamModalProps) {
     mutationFn: (file: File) => postImage(file),
     onSuccess: (imgUrl: string) => {
       // 이미지 URL을 성공적으로 받으면 그룹 수정 요청
-      if (validateValueOnSubmit('teamName', TeamNames, localTeamName)) {
+      if (
+        validateValueOnSubmit('teamName', TeamNames, localTeamName, teamName)
+      ) {
         editGroup({ groupId: id, image: imgUrl, name: localTeamName });
       }
     },

--- a/src/components/team/banner/EditTeamModal.tsx
+++ b/src/components/team/banner/EditTeamModal.tsx
@@ -66,6 +66,7 @@ export default function EditTeamModal({ isOpen, onClose }: EditTeamModalProps) {
     onSettled: () => {
       // 쿼리 무효화 및 리패치
       queryClient.invalidateQueries({ queryKey: ['group', id] });
+      queryClient.invalidateQueries({ queryKey: ['user'] });
     },
     onError: (error) => {
       console.error('그룹 생성 실패:', error);
@@ -83,6 +84,10 @@ export default function EditTeamModal({ isOpen, onClose }: EditTeamModalProps) {
       ) {
         editGroup({ groupId: id, image: imgUrl, name: localTeamName });
       }
+    },
+    onSettled: () => {
+      // 쿼리 무효화 및 리패치
+      queryClient.invalidateQueries({ queryKey: ['user'] });
     },
     onError: (error) => {
       console.error('이미지 업로드 실패:', error);

--- a/src/components/team/member/ExileDropdown.tsx
+++ b/src/components/team/member/ExileDropdown.tsx
@@ -11,12 +11,13 @@ export default function ExileDropdown({ onSelect }: ExileDropdownProps) {
   ];
 
   const moreIcon = (
-    <div className="flex h-[10px] w-[10px] items-center">
+    <div className="flex h-[10px] w-[20px] items-center">
       <Image
         src="/icons/kebab_large.svg"
         alt="더보기 아이콘"
         width={4}
         height={10}
+        className="mx-auto"
       />
     </div>
   );

--- a/src/components/team/member/MemberBox.tsx
+++ b/src/components/team/member/MemberBox.tsx
@@ -65,7 +65,10 @@ export default function MemberBox({
             {userEmail}
           </p>
         </div>
-        <div onClick={handleDropdownClick}>
+        <div
+          onClick={handleDropdownClick}
+          className="mr-[-10px] w-[20px] cursor-pointer rounded-full hover:bg-[#ffffff1c]"
+        >
           <ExileDropdown onSelect={handleExileClick} />
         </div>
       </div>

--- a/src/components/team/taskList/AddTaskListModal.tsx
+++ b/src/components/team/taskList/AddTaskListModal.tsx
@@ -82,8 +82,17 @@ export default function AddTaskListModal({
         }
       }
 
-      // 새로운 taskListData 추가
-      existingTaskLists.push(taskListData);
+      // 기존 이름과 겹치는지 확인
+      const existingTaskIndex = existingTaskLists.findIndex(
+        (task) => task.name === taskListData.name
+      );
+
+      // 기존 이름이 있는 경우 색상 업데이트, 없으면 새로 추가
+      if (existingTaskIndex !== -1) {
+        existingTaskLists[existingTaskIndex].color = taskListData.color;
+      } else {
+        existingTaskLists.push(taskListData);
+      }
 
       // 업데이트된 배열을 로컬 스토리지에 저장
       localStorage.setItem(

--- a/src/components/team/taskList/DeleteTaskListModal.tsx
+++ b/src/components/team/taskList/DeleteTaskListModal.tsx
@@ -51,6 +51,35 @@ export default function DeleteTaskListModal({
       return;
     }
     deleteList(taskListId);
+
+    // 로컬 스토리지에서 기존 TaskLists 가져오기 (없으면 빈 배열)
+    const existingTaskListsString = localStorage.getItem(`TaskLists_${id}`);
+
+    let existingTaskLists = [];
+    if (existingTaskListsString) {
+      try {
+        existingTaskLists = JSON.parse(existingTaskListsString);
+
+        // JSON 파싱 후 배열인지 확인
+        if (!Array.isArray(existingTaskLists)) {
+          existingTaskLists = []; // 배열이 아닐 경우 빈 배열로 초기화
+        }
+      } catch (error) {
+        console.error(
+          '로컬 스토리지에서 TaskLists를 파싱하는 중 오류 발생:',
+          error
+        );
+        existingTaskLists = []; // 파싱 오류 발생 시 빈 배열로 초기화
+      }
+    }
+
+    // 삭제할 항목의 name을 가진 요소 필터링
+    const updatedTaskLists = existingTaskLists.filter(
+      (task) => task.name !== taskName
+    );
+
+    // 업데이트된 배열을 로컬 스토리지에 저장
+    localStorage.setItem(`TaskLists_${id}`, JSON.stringify(updatedTaskLists));
   };
 
   return (

--- a/src/components/team/taskList/TaskBar.tsx
+++ b/src/components/team/taskList/TaskBar.tsx
@@ -6,6 +6,7 @@ import CircleGraph from '../CircleGraph';
 import EditDropdown from '../EditDropdown';
 import DeleteTaskListModal from './DeleteTaskListModal';
 import EditTaskListModal from './EditTaskListModal';
+import Link from 'next/link';
 
 interface TaskBarProps {
   name: string;
@@ -13,7 +14,13 @@ interface TaskBarProps {
   id: number;
 }
 
+interface StoredTaskList {
+  name: string;
+  color: string;
+}
+
 export default function TaskBar({ name, tasks, id }: TaskBarProps) {
+  const { id: groupId } = useTeamStore();
   // 1. 총 task의 개수
   const totalTasks = tasks.length;
   // 2. doneAt이 null이 아닌 task의 개수
@@ -33,19 +40,16 @@ export default function TaskBar({ name, tasks, id }: TaskBarProps) {
   } = useModal();
 
   const moreIcon = (
-    <div className="flex h-[10px] w-[10px] items-center">
+    <div className="flex w-[20px] items-center">
       <Image
         src="/icons/kebab_large.svg"
         alt="더보기 아이콘"
         width={4}
-        height={10}
+        height={20}
+        className="mx-auto"
       />
     </div>
   );
-
-  const handleDropdownClick = (e: React.MouseEvent) => {
-    e.stopPropagation(); // 클릭 이벤트 전파 방지
-  };
 
   // 드롭다운에서 선택된 옵션을 처리하는 함수
   const handleSelect = (option: Option) => {
@@ -55,54 +59,79 @@ export default function TaskBar({ name, tasks, id }: TaskBarProps) {
       deleteListOpenModal();
     } // '삭제하기'를 선택했을 때
   };
+
+  // 로컬 스토리지에서 taskLists 가져오기
+  const storedTaskLists = JSON.parse(
+    localStorage.getItem(`TaskLists_${groupId}`) || '[]'
+  );
+  const currentTaskList = storedTaskLists.find(
+    (taskList: StoredTaskList) => taskList.name === name
+  );
+
+  // 찾은 taskList의 색상을 가져오거나 기본 색상을 사용
+  const taskListColor = currentTaskList ? currentTaskList.color : '#0eaf6f'; // 기본 색상
+
   return (
-    <div className="flex h-[40px] cursor-pointer justify-between bg-background-secondary ">
-      <div className="flex items-center justify-between gap-[10px]">
-        <div className="h-full w-[12px] shrink-0 rounded-bl-[12px] rounded-br-[0px] rounded-tl-[12px] rounded-tr-[0px] bg-point-purple">
-          &nbsp;
-        </div>
-        <p className="break-words break-all text-md-medium">{name}</p>
-      </div>
-      <div className="mr-[10px] flex items-center gap-[10px]">
-        <div className="flex h-[25px] w-[58px] items-center justify-between rounded-[12px] bg-background-primary px-[8px] py-[4px]">
-          {doneRate === 100 ? (
-            <Image
-              src="/icons/progress_done.svg"
-              alt="완료 아이콘"
-              width={17}
-              height={17}
-              className="flex-shrink-0"
-            />
-          ) : (
-            <CircleGraph
-              backgroundColor="#ffffff"
-              gradientColorStart="#10B981"
-              gradientColorEnd="#10B981"
-              radius={6}
-              percentage={doneRate}
-              strokeWidth={3}
-            />
-          )}
-          <p className="text-md-regular text-brand-primary">
-            {doneTasksCount}/{totalTasks}
+    <div className="flex h-[40px] justify-between bg-background-secondary ">
+      <Link
+        href={`/${id}/tasks`}
+        className="flex flex-grow cursor-pointer justify-between"
+      >
+        <div className="flex flex-grow items-center justify-start gap-[10px]">
+          <div
+            className="h-full w-[12px] shrink-0 rounded-bl-[12px] rounded-br-[0px] rounded-tl-[12px] rounded-tr-[0px]"
+            style={{ backgroundColor: taskListColor }}
+          >
+            &nbsp;
+          </div>
+          <p className="break-words break-all text-left text-md-medium">
+            {name}
           </p>
         </div>
-        <div onClick={handleDropdownClick}>
-          <EditDropdown triggerIcon={moreIcon} onSelect={handleSelect} />
+        <div className="flex items-center justify-between">
+          <div className="mr-[10px] flex items-center gap-[10px]">
+            <div className="flex h-[25px] w-[58px] items-center justify-between rounded-[12px] bg-background-primary px-[8px] py-[4px]">
+              {doneRate === 100 ? (
+                <Image
+                  src="/icons/progress_done.svg"
+                  alt="완료 아이콘"
+                  width={17}
+                  height={17}
+                  className="flex-shrink-0"
+                />
+              ) : (
+                <CircleGraph
+                  backgroundColor="#ffffff"
+                  gradientColorStart="#10B981"
+                  gradientColorEnd="#10B981"
+                  radius={6}
+                  percentage={doneRate}
+                  strokeWidth={3}
+                />
+              )}
+              <p className="text-md-regular text-brand-primary">
+                {doneTasksCount}/{totalTasks}
+              </p>
+            </div>
+          </div>
         </div>
-        <EditTaskListModal
-          isOpen={editListIsOpen}
-          onClose={editListCloseModal}
-          initialTaskListName={name}
-          taskListId={id}
-        />
-        <DeleteTaskListModal
-          isOpen={deleteListIsOpen}
-          onClose={deleteListCloseModal}
-          taskListId={id}
-          taskName={name}
-        />
+      </Link>
+      <div className="m-auto mr-[5px] w-[20px] cursor-pointer rounded-full hover:bg-[#ffffff1c]">
+        <EditDropdown triggerIcon={moreIcon} onSelect={handleSelect} />
       </div>
+      <EditTaskListModal
+        isOpen={editListIsOpen}
+        onClose={editListCloseModal}
+        initialTaskListName={name}
+        taskListId={id}
+        taskListColor={taskListColor}
+      />
+      <DeleteTaskListModal
+        isOpen={deleteListIsOpen}
+        onClose={deleteListCloseModal}
+        taskListId={id}
+        taskName={name}
+      />
     </div>
   );
 }

--- a/src/components/team/taskList/TaskList.tsx
+++ b/src/components/team/taskList/TaskList.tsx
@@ -1,10 +1,28 @@
 import { useModal } from '@hooks/useModal';
 import { useTeamStore } from '@/src/stores/teamStore';
+import {
+  DndContext,
+  closestCenter,
+  useSensor,
+  useSensors,
+  PointerSensor,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import TaskBar from './TaskBar';
 import AddTaskListModal from './AddTaskListModal';
-import Link from 'next/link';
+import SortableItem from './SortableItem';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { patchTaskListOrder } from '@/src/api/tasks/taskListAPI';
 
 export default function TaskList() {
+  const queryClient = useQueryClient();
+
   const {
     isOpen: addListIsOpen,
     onOpen: addListOpenModal,
@@ -42,16 +60,14 @@ export default function TaskList() {
           아직 할 일 목록이 없습니다.
         </p>
       )}
+
       <div className="flex flex-col gap-[10px]">
         {taskLists.map((taskList) => (
-          <Link href={`/${id}/tasks`}>
-            <TaskBar
-              key={taskList.id}
-              name={taskList.name}
-              tasks={taskList.tasks}
-              id={taskList.id}
-            />
-          </Link>
+          <TaskBar
+            name={taskList.name}
+            tasks={taskList.tasks}
+            id={taskList.id}
+          />
         ))}
       </div>
     </section>

--- a/src/components/team/taskList/tagColors.ts
+++ b/src/components/team/taskList/tagColors.ts
@@ -1,0 +1,12 @@
+export const tagColors = [
+  { label: 'Lavender Purple', color: '#A533FF' },
+  { label: 'Sunset Orange', color: '#f71884' },
+  { label: 'Mint Green', color: '#77ec8c' },
+  { label: 'Sky Blue', color: '#33AFFF' },
+  { label: 'Lemon Yellow', color: '#FFF333' },
+  { label: 'Coral Pink', color: '#FF7F7F' },
+  { label: 'Ocean Blue', color: '#035580' },
+  { label: 'Forest Green', color: '#2D6A4F' },
+  { label: 'Sunflower', color: '#ff9900' },
+  { label: 'Peach', color: '#7e5633' },
+];

--- a/src/hooks/useValidation.tsx
+++ b/src/hooks/useValidation.tsx
@@ -36,8 +36,13 @@ export const useValidation = () => {
   const validateValueOnSubmit = (
     field: string,
     list: string[],
-    item: string
+    item: string,
+    currentName?: string
   ) => {
+    // 현재 이름과 같다면 중복 체크 생략
+    if (item === currentName) {
+      return true;
+    }
     if (list.includes(item)) {
       setError(field, true, '이미 존재하는 이름입니다.');
       return false;

--- a/src/styles/scroll.module.css
+++ b/src/styles/scroll.module.css
@@ -38,3 +38,16 @@
 .sidebarScroll::-webkit-scrollbar-track {
   background: transparent; /* 스크롤바 트랙 색상 */
 }
+
+.dropdownScroll::-webkit-scrollbar {
+  width: 5px; /* 스크롤바 너비 */
+}
+
+.dropdownScroll::-webkit-scrollbar-thumb {
+  background-color: #10b981; /* 스크롤바 색상 */
+  border-radius: 10px; /* 둥글게 만들기 */
+}
+
+.dropdownScroll::-webkit-scrollbar-track {
+  background: transparent; /* 스크롤바 트랙 색상 */
+}

--- a/src/styles/scroll.module.css
+++ b/src/styles/scroll.module.css
@@ -25,3 +25,16 @@
 .autoTextarea::-webkit-scrollbar-track {
   background: transparent; /* 스크롤바 트랙 색상 */
 }
+
+.sidebarScroll::-webkit-scrollbar {
+  width: 5px; /* 스크롤바 너비 */
+}
+
+.sidebarScroll::-webkit-scrollbar-thumb {
+  background-color: #10b981; /* 스크롤바 색상 */
+  border-radius: 10px; /* 둥글게 만들기 */
+}
+
+.sidebarScroll::-webkit-scrollbar-track {
+  background: transparent; /* 스크롤바 트랙 색상 */
+}


### PR DESCRIPTION
# 작업분류
- [x] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
팀페이지 할일목록 색상 추가 및 navbar 수정

# 작업 상세 내용
1. 할 일 목록을 추가/수정/삭제시 로컬 스토리지의 값을 연동하도록 구현

![2024-10-28 18;05;49](https://github.com/user-attachments/assets/8367ea0f-a2aa-4ae2-9336-32ed188f8776)



2. Navbar :
- 글씨 넘치는 현상 해결
- 현재 페이지와 드롭다운이 보여주는 메뉴 동기화
- 모바일에서 사이드바로 변하게 하기
- 팀을 생성, 수정했을 때 바로 refetch
-teams 배열이 무한으로 변경되어 메모이제이션 수행

![2024-10-28 17;29;04](https://github.com/user-attachments/assets/197d022e-be8b-453f-a5b6-41bb7a8f43cc)


3. 드롭다운: 스크롤로 구현

![2024-10-28 17;38;03](https://github.com/user-attachments/assets/92624630-aa43-4fd0-a72e-a2bfccefffa6)



# 리뷰 요구사항
색상 추가 로직은 로컬 스토리지라는 한계가 있습니다...
모두가 반대하면 그냥 랜덤 생성으로 바꿀 의향이 있습니다

# 연관된 Jira 티켓 번호
ZERO-136
