### PR TITLE
ZERO-150: 리스트페이지 1차 디버깅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
+        "dnd-kit": "^0.0.2",
         "next": "14.2.14",
         "react": "^18",
         "react-datepicker": "^7.5.0",
@@ -4669,6 +4670,13 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dnd-kit": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/dnd-kit/-/dnd-kit-0.0.2.tgz",
+      "integrity": "sha512-d8AYd6I7D2b5u882+QNVGw0slBAt851/LWZ2j/pU+onf5/TGEKXeb47sCyhPYKEAUXp4oLfvWfNCqfkU03R1lw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
     },
     "node_modules/doctrine": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
+    "dnd-kit": "^0.0.2",
     "next": "14.2.14",
     "react": "^18",
     "react-datepicker": "^7.5.0",

--- a/src/components/@shared/SideBar.tsx
+++ b/src/components/@shared/SideBar.tsx
@@ -38,11 +38,19 @@ export default function SideBar({
   // 사이드바 밖 부분을 클릭시 닫기위한 로직
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (
-        sideBarRef.current &&
-        !sideBarRef.current.contains(event.target as Node)
-      ) {
-        onClose();
+      // 사이드바의 크기와 위치를 정확하게 측정 후 닫기
+      if (sideBarRef.current) {
+        const { left, right, top, bottom } =
+          sideBarRef.current.getBoundingClientRect();
+        const isOutside =
+          event.clientX < left ||
+          event.clientX > right ||
+          event.clientY < top ||
+          event.clientY > bottom;
+
+        if (isOutside) {
+          onClose();
+        }
       }
     };
 
@@ -94,14 +102,15 @@ export default function SideBar({
       <div className="mt-10 h-full">{children}</div>
       <div className={classes.completeButtonWrapper}>
         {button === 'completebutton' ? (
-          <Button width={138} height={40} shape="round">
-            <div
-              onClick={clickEvent}
-              className="flex items-center justify-center gap-1"
-            >
-              <CheckWhiteIcon />
-              <span>완료하기</span>
-            </div>
+          <Button
+            className="flex items-center justify-center gap-1"
+            width={138}
+            height={40}
+            shape="round"
+            onClick={clickEvent}
+          >
+            <CheckWhiteIcon />
+            <span>완료하기</span>
           </Button>
         ) : (
           <Button
@@ -112,14 +121,11 @@ export default function SideBar({
             height={40}
             border="green"
             shape="round"
+            onClick={clickEvent}
+            className="flex items-center justify-center gap-1"
           >
-            <div
-              onClick={clickEvent}
-              className="flex items-center justify-center gap-1"
-            >
-              <CheckGreenIcon />
-              <span>완료 취소하기</span>
-            </div>
+            <CheckGreenIcon />
+            <span>완료 취소하기</span>
           </Button>
         )}
       </div>

--- a/src/components/tasks/AddTaskForm.tsx
+++ b/src/components/tasks/AddTaskForm.tsx
@@ -30,7 +30,7 @@ const frequencyOptions: Option[] = [
 
 export default function AddTaskForm({ onClose }: AddTaskFormProps) {
   const queryClient = useQueryClient();
-  const { date: contextDate, getCurrentMonth } = useDate();
+  const { inputDate, getCurrentMonth } = useDate();
   const { groupId, taskListId } = useTaskListStore();
   const [isOpen, setIsOpen] = useState(false);
   const [selectedFrequency, setSelectedFrequency] = useState<Option>(
@@ -45,7 +45,7 @@ export default function AddTaskForm({ onClose }: AddTaskFormProps) {
     mode: 'onChange',
     defaultValues: {
       ...TASK_REQUEST_INIT.POST,
-      startDate: toKSTISOString(contextDate),
+      startDate: toKSTISOString(inputDate),
     },
   });
 

--- a/src/components/tasks/Calender.tsx
+++ b/src/components/tasks/Calender.tsx
@@ -39,6 +39,11 @@ export default function Calender({
   const handleDateChange = (newDate: Date | null) => {
     if (newDate) {
       const dayjsDate = dayjs(newDate); // Date를 Dayjs로 변환
+      const isBeforeToday = dayjsDate.isBefore(dayjs(), 'day'); // 오늘 이전 날짜 확인
+      // isInput 상태일 때 오늘 이전 날짜는 선택할 수 없도록 처리
+      if (isInput && isBeforeToday) {
+        return; // 아무 동작도 하지 않음
+      }
       setSelectedDate(dayjsDate); // 선택된 날짜 업데이트
       setDate(dayjsDate); // 선택된 날짜 Context에 업데이트
       if (onDateChange) {
@@ -94,6 +99,7 @@ export default function Calender({
         const day = dayjs(date);
         const isDisplayedMonth = day.isSame(displayedMonth, 'month');
         const isToday = day.isSame(today, 'day');
+        const isBeforeToday = day.isBefore(today, 'day');
         const isSelected =
           day.isSame(selectedDate, 'month') &&
           day.date() === selectedDate.date();
@@ -106,6 +112,9 @@ export default function Calender({
         }
         if (isSelected) {
           return styles.selectedDay;
+        }
+        if (isInput && isBeforeToday) {
+          return styles.disabledDay;
         }
         return styles.day;
       }}

--- a/src/components/tasks/Calender.tsx
+++ b/src/components/tasks/Calender.tsx
@@ -31,23 +31,28 @@ export default function Calender({
   onDateChange,
   isInput = false,
 }: CalenderProps) {
-  const { date: contextDate, setDate, today } = useDate();
+  const { date: contextDate, setInputDate, setDate, today } = useDate();
   const [selectedDate, setSelectedDate] = useState<Dayjs>(dayjs(contextDate));
   const [displayedMonth, setDisplayedMonth] = useState(dayjs(contextDate));
   const { isMobile } = useViewportSize();
 
   const handleDateChange = (newDate: Date | null) => {
     if (newDate) {
-      const dayjsDate = dayjs(newDate); // Date를 Dayjs로 변환
-      const isBeforeToday = dayjsDate.isBefore(dayjs(), 'day'); // 오늘 이전 날짜 확인
-      // isInput 상태일 때 오늘 이전 날짜는 선택할 수 없도록 처리
+      const dayjsDate = dayjs(newDate);
+      const isBeforeToday = dayjsDate.isBefore(dayjs(), 'day');
       if (isInput && isBeforeToday) {
-        return; // 아무 동작도 하지 않음
+        return;
       }
-      setSelectedDate(dayjsDate); // 선택된 날짜 업데이트
-      setDate(dayjsDate); // 선택된 날짜 Context에 업데이트
+      setSelectedDate(dayjsDate);
+
+      if (isInput) {
+        setInputDate(dayjsDate);
+      } else {
+        setDate(dayjsDate);
+      }
+
       if (onDateChange) {
-        onDateChange(dayjsDate); // 선택된 날짜 부모 컴포넌트에 전달
+        onDateChange(dayjsDate);
       }
       onClose();
     }

--- a/src/components/tasks/Layout/TaskList.tsx
+++ b/src/components/tasks/Layout/TaskList.tsx
@@ -1,23 +1,36 @@
 import Link from 'next/link';
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 import { useTaskListStore } from '@/src/stores/taskListStore';
 import TaskCard from '../TaskCard';
 
 export default function TaskList() {
+  const router = useRouter();
+  const { query } = router;
+  const { teamid } = query;
   const { taskLists, taskListId, setTaskListId, tasks, setTasks } =
     useTaskListStore();
 
-  // 선택된 taskList의 tasks[] 가져오기
-  const handleButtonClick = (selectedTaskListId: number | undefined) => {
-    if (selectedTaskListId !== taskListId) {
-      const selectedList = taskLists.find(
-        (taskList) => taskList.id === taskListId
-      );
-      if (selectedList) {
-        setTasks(selectedList.tasks);
-        setTaskListId(selectedTaskListId);
-      }
+  // 선택된 taskList의 tasks[]를 가져오는 함수
+  const fetchTasks = (id: number) => {
+    const selectedList = taskLists.find((taskList) => taskList.id === id);
+    if (selectedList) {
+      setTasks(selectedList.tasks);
+    } else {
+      setTasks([]);
     }
   };
+
+  const handleButtonClick = () => {
+    const newTaskListId = Number(teamid);
+    setTaskListId(newTaskListId);
+  };
+
+  useEffect(() => {
+    if (taskListId) {
+      fetchTasks(taskListId);
+    }
+  }, [taskListId, taskLists]);
 
   return (
     <section className="flex flex-col gap-4">
@@ -34,7 +47,7 @@ export default function TaskList() {
             <Link href={{ pathname: `/${taskList.id}/tasks` }}>
               <button
                 type="button"
-                onClick={() => handleButtonClick(taskList.id)}
+                onClick={handleButtonClick}
                 className="pb-1"
               >
                 {taskList.name}

--- a/src/components/tasks/Layout/TaskList.tsx
+++ b/src/components/tasks/Layout/TaskList.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useRouter } from 'next/router';
 import { useTaskListStore } from '@/src/stores/taskListStore';
 import TaskCard from '../TaskCard';
@@ -8,29 +8,38 @@ export default function TaskList() {
   const router = useRouter();
   const { query } = router;
   const { teamid } = query;
-  const { taskLists, taskListId, setTaskListId, tasks, setTasks } =
-    useTaskListStore();
-
-  // 선택된 taskList의 tasks[]를 가져오는 함수
-  const fetchTasks = (id: number) => {
-    const selectedList = taskLists.find((taskList) => taskList.id === id);
-    if (selectedList) {
-      setTasks(selectedList.tasks);
-    } else {
-      setTasks([]);
-    }
-  };
-
-  const handleButtonClick = () => {
-    const newTaskListId = Number(teamid);
-    setTaskListId(newTaskListId);
-  };
+  const {
+    taskLists,
+    taskListId: currentTaskListId,
+    setTaskListId,
+    tasks,
+    setTasks,
+  } = useTaskListStore();
 
   useEffect(() => {
-    if (taskListId) {
-      fetchTasks(taskListId);
+    if (teamid) {
+      setTaskListId(Number(teamid));
     }
-  }, [taskListId, taskLists]);
+  }, [teamid, setTaskListId]);
+
+  // 선택된 taskList의 tasks[]를 가져오는 함수
+  const fetchTasks = useCallback(
+    (taskListId: number | undefined) => {
+      const selectedList = taskLists.find(
+        (taskList) => taskList.id === taskListId
+      );
+      setTasks(selectedList ? selectedList.tasks : []);
+    },
+    [taskLists, setTasks]
+  );
+
+  useEffect(() => {
+    fetchTasks(currentTaskListId);
+  }, [currentTaskListId, fetchTasks]);
+
+  useEffect(() => {
+    setTasks(tasks);
+  }, [tasks, setTasks]);
 
   return (
     <section className="flex flex-col gap-4">
@@ -39,17 +48,13 @@ export default function TaskList() {
           <li
             key={taskList.id}
             className={
-              taskListId === taskList.id
+              currentTaskListId === taskList.id
                 ? 'border-b-[1px] border-b-white text-white'
                 : 'text-text-default'
             }
           >
             <Link href={{ pathname: `/${taskList.id}/tasks` }}>
-              <button
-                type="button"
-                onClick={handleButtonClick}
-                className="pb-1"
-              >
+              <button type="button" className="pb-1">
                 {taskList.name}
               </button>
             </Link>

--- a/src/contexts/DateContext.tsx
+++ b/src/contexts/DateContext.tsx
@@ -1,11 +1,19 @@
 /* eslint-disable react/jsx-no-constructed-context-values */
-import { createContext, useContext, useState, ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+} from 'react';
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
 
 interface DateContextProps {
   date: dayjs.Dayjs;
   setDate: (date: dayjs.Dayjs) => void;
+  inputDate: dayjs.Dayjs;
+  setInputDate: (date: dayjs.Dayjs) => void;
   today: dayjs.Dayjs;
   getCurrentMonth: () => number;
 }
@@ -15,8 +23,13 @@ const DateContext = createContext<DateContextProps | undefined>(undefined);
 export function DateProvider({ children }: { children: ReactNode }) {
   const today = dayjs(); // 초기값, 오늘 날짜
   const [date, setDate] = useState<dayjs.Dayjs>(today); // 선택한 날짜
+  const [inputDate, setInputDate] = useState<dayjs.Dayjs>(date);
 
   dayjs.locale('ko');
+
+  useEffect(() => {
+    setInputDate(date);
+  }, [date]);
 
   // 현재 날짜의 월 추출
   const getCurrentMonth = () => {
@@ -24,7 +37,16 @@ export function DateProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <DateContext.Provider value={{ date, setDate, today, getCurrentMonth }}>
+    <DateContext.Provider
+      value={{
+        today,
+        date,
+        setDate,
+        inputDate,
+        setInputDate,
+        getCurrentMonth,
+      }}
+    >
       {children}
     </DateContext.Provider>
   );

--- a/src/styles/calendar.module.css
+++ b/src/styles/calendar.module.css
@@ -35,3 +35,8 @@ div.selectedDay {
 .day {
   color: white;
 }
+
+.disabledDay {
+  pointer-events: none;
+  color: #64748b;
+}


### PR DESCRIPTION
## 작업분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 리팩토링
- [ ] 기타

## 작업개요

- 리스트페이지 1차 디버깅

## 작업 상세 내용

1. 페이지의 li 태그가 증가할 경우, 사이드바 내부 클릭시 사이드바 자동 닫힘
**→ 사이드바 크기 측정 로직 추가**

2. 사이드 바 내부 완료 버튼을 빠르게 클릭할 경우, 미응답
**→ `div` 태그 제거 후 `button` 태그로 `onClick` 속성 이동**

2. 할 일 추가 모달에서 현재 날짜 기준 전 날로 선택 후 제출하면 POST되지 않음
**→ 현재 날짜 기준 전 날을 선택하지 못하도록 수정**

3. 할 일 생성 모달에서 캘린더의 날짜 값과 페이지의 날짜값이 연동됨
**→ 캘린더 date와 페이지 date의 상태 분리**

5. taskList의 버튼 클릭 시 남아있던 이전 상태를 렌더링
**→ useEffect 적용 & 리팩토링**

6. 같은 이름의 taskList 생성 불가

---

## 스크린샷

> **사이드바**

![SHANA 사이드바 디버깅](https://github.com/user-attachments/assets/7f307915-f3e3-45e2-bcf2-d57c025fad77)


> **날짜**

![SHANA 날짜 값 연동 디버깅](https://github.com/user-attachments/assets/0637cb44-a189-42b0-8c86-720f1e8ee051)

> **할 일 생성 모달 내부 캘린더** 

![SHANA 캘린더 디버깅](https://github.com/user-attachments/assets/250d31dc-f461-446d-b08c-b59a74248b8b)

> **할 일 목록 생성 모달**

![localhost_3000_2200_tasks](https://github.com/user-attachments/assets/99cbf18f-b982-42b8-99f3-bdbf4a3ff12f)


---

## 리뷰 요구사항

> 공통 컴포넌트 SideBar에 로직을 추가했습니다.

## 연관된 Jira 티켓 번호

> ZERO-150