### PR TITLE
ZERO-125 : 네브바 로고 중복 버그 수정

### DIFF
--- a/src/components/@shared/NavBar.tsx
+++ b/src/components/@shared/NavBar.tsx
@@ -98,7 +98,7 @@ export default function NavBar() {
     <header className=" flex h-16 items-center justify-center border-b border-border-primary border-opacity-10 bg-background-secondary px-6">
       <nav className="flex h-8 w-[1200px]  items-center justify-between text-text-primary max-xl:w-full max-md:w-full ">
         <div className="flex items-center gap-10 max-md:gap-5">
-          {isLogoOnlyPage && (
+          {isLogoOnlyPage ? (
             <Link href="/">
               <div className="block max-xl:hidden">
                 <Image src={PCLogo} alt="로고" width={158} height={32} />
@@ -107,8 +107,9 @@ export default function NavBar() {
                 <Image src={PCLogo} alt="로고" width={102} height={20} />
               </div>
             </Link>
+          ) : (
+            data && <NavBarTeam data={data} />
           )}
-          {data && <NavBarTeam data={data} />}
         </div>
         {!isLogoOnlyPage && (
           <div>


### PR DESCRIPTION
## 작업분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 리팩토링
- [ ] 기타

## 작업개요

- 네브바 중복 버그 수정

## 작업 상세 내용
- 네브바 로고 숨기는 부분을 and연산자에서 삼항연산자로 수정


## 스크린샷

![11](https://github.com/user-attachments/assets/d834f93d-8dbd-43f0-84be-97c4cf7e62ba)

![22](https://github.com/user-attachments/assets/ca5e7a0b-21b1-4bc8-b5d5-d4dfbd191241)
---

## 리뷰 요구사항

## 연관된 Jira 티켓 번호
- ZERO-125
