### PR TITLE
ZERO-163:  404 페이지

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,7 +20,7 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'lh3.googleusercontent.com', // 구글 프로필 이미지 도메인 추가
         port: '', // 특정 포트를 허용하려면 설정
-        pathname: '/Coworkers/**', // 모든 경로를 허용
+        pathname: '/**', // 모든 경로를 허용
       },
       {
         protocol: 'http',

--- a/src/components/@shared/NavBar.tsx
+++ b/src/components/@shared/NavBar.tsx
@@ -16,7 +16,6 @@ export default function NavBar() {
   const [isClient, setIsClient] = useState(false);
   const { data } = useUserData();
   const handleLogout = () => {
-    // localStorage.removeItem('userStorage');
     logout();
     router.push('/signin');
   };

--- a/src/components/@shared/NavBar.tsx
+++ b/src/components/@shared/NavBar.tsx
@@ -6,15 +6,18 @@ import { useUserData } from '@hooks/mysetting/useUserData';
 import PCLogo from 'public/images/logo_pc.png';
 import Link from 'next/link';
 import Image from 'next/image';
+import { useUserStore } from '@/src/stores/useUserStore';
 import NavBarTeam from './NavBar_Team';
 
 export default function NavBar() {
   const router = useRouter();
+  const { logout } = useUserStore();
   const [isLogoOnlyPage, setIsLogoOnlyPage] = useState(false);
   const [isClient, setIsClient] = useState(false);
   const { data } = useUserData();
   const handleLogout = () => {
-    localStorage.removeItem('userStorage');
+    // localStorage.removeItem('userStorage');
+    logout();
     router.push('/signin');
   };
 

--- a/src/components/@shared/UserNotFound.tsx
+++ b/src/components/@shared/UserNotFound.tsx
@@ -14,9 +14,9 @@ export default function UserNotFound() {
         />
       </div>
       <p className="mt-[20px] text-center text-[20px]">
-        유저 정보를 찾을 수 없어요.
+        찾을 수 없는 페이지입니다.
       </p>
-      <Link href="/signin">
+      <Link href="/">
         <Button
           width={200}
           height={48}
@@ -26,7 +26,7 @@ export default function UserNotFound() {
           fontSize="14"
           className="mx-auto mt-[50px]"
         >
-          로그인 하러 가기
+          홈으로 가기
         </Button>
       </Link>
     </div>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return (
+    <div>
+      <div>404 페이지</div>
+    </div>
+  );
+}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,7 +1,5 @@
+import UserNotFound from '@components/@shared/UserNotFound';
+
 export default function NotFound() {
-  return (
-    <div>
-      <div>404 페이지</div>
-    </div>
-  );
+  return <UserNotFound />;
 }


### PR DESCRIPTION
## 작업분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 리팩토링
- [x] 기타

## 작업개요

- 404 페이지 추가
- 구글 프로필 이미지 경로 수정
- 로그아웃 수정

## 작업 상세 내용

- 영선님이 작업하신 기존 UserNotFound 그대로 가져와서 텍스트랑 경로만 바꿨습니다.
- next.config.mjs 파일에 구글 프로필 이미지 경로를 수정했습니다.
- 로그아웃할 때 전역으로 관리하던 유저 상태를 지우도록 했습니다.

## 스크린샷

- 근데 문제가 하나 있습니다. 404 페이지의 네비바에서 로고가 안보입니다. 로그인 중일 때는 404 페이지의 네비바는 온전하게 뜹니다. 수정이 필요해보입니다.

- 로그인 안 된 상태
![스크린샷(160)](https://github.com/user-attachments/assets/78d0729b-c4c8-49d5-817b-c26777d486de)
- 로그인 된 상태
![스크린샷(161)](https://github.com/user-attachments/assets/8c698078-2316-4a9e-9c59-305d85a19051)


## 리뷰 요구사항


## 연관된 Jira 티켓 번호
ZERO-163
