### PR TITLE
CI/CD develop 브랜치 배포 자동화 GitHub Action

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -1,0 +1,30 @@
+name: Sync forked repo for deploy
+
+on:
+  push:
+    branches: [dev]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+      - name: creates output
+        run: sh ./build.sh
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.HYEOKSU_GITHUB_KEY }}
+        with:
+          source-directory: "output"
+          destination-github-username: hyeoksuJ
+          destination-repository-name: Coworkers
+          user-email: ${{ secrets.HYEOKSU_ACCOUNT_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: dev
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Sync forked repo for deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+      - name: creates output
+        run: sh ./build.sh
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.HYEOKSU_GITHUB_KEY }}
+        with:
+          source-directory: "output"
+          destination-github-username: hyeoksuJ
+          destination-repository-name: Coworkers
+          user-email: ${{ secrets.HYEOKSU_ACCOUNT_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY


### PR DESCRIPTION
## 작업분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

## 작업개요

develop 브랜치 자동 배포

## 작업 상세 내용

- dev브랜치에 push 하는 경우 해당 브랜치를 제 개인 레포로 sync 시킨 후에 vercel 에 배포하는 과정을 자동화 했습니다.
- 해당 동작을 수행하는 github action (deploy-dev.yml) 과 해당 action 을 실행하는데 필요한 build.sh를 추가하였습니다.


## 스크린샷


## 리뷰 요구사항


## 연관된 Jira 티켓 번호

